### PR TITLE
add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+dist: trusty
+language: generic
+compiler:
+  - gcc
+notifications:
+  email:
+    on_success: never
+    on_failure: never
+
+env:
+  global:
+    - ROS_DISTRO=kinetic
+    - DOCKER_IMAGE=rosindustrial/noether:kinetic
+    - NOT_TEST_INSTALL=true
+    - BEFORE_SCRIPT='catkin config -w $CATKIN_WORKSPACE --no-install'
+  matrix:
+    - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - source .ci_config/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - ROS_DISTRO=kinetic
     - DOCKER_IMAGE=rosindustrial/noether:kinetic
-    - NOT_TEST_INSTALL=true
+    - NOT_TEST_BUILD=true
     - BEFORE_SCRIPT='catkin config -w $CATKIN_WORKSPACE --no-install'
   matrix:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu


### PR DESCRIPTION
Based on rosindustrial/a5:kinetic docker image which i will provide more documentation on shortly. https://hub.docker.com/r/rosindustrial/a5/

Basically, this image has the following features:
 - VTK 7.1
 - PCL 1.8 built on VTK 7.1
 - ros industrial core

The CI currently fails due to failed tests.