### PR TITLE
Improved source dependencies installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,72 @@
-﻿# Noether
+# Noether
 
-This package depends on PCL 1.8 and VTK 7.1.  Install VTK first and make sure that PCL is compiled against 7.1 or there will be run time errors.
+Tool path planning and surface segmenter
+
+---
 ## Prerequisites
-These packages run on Ubuntu 16.04
+- These packages run on Ubuntu 16.04 and ROS
+- Uses the catkin tools build system
 
-### Installing VTK 7.1:
-```
-git clone https://github.com/Kitware/VTK.git
-cmake .
-make
-sudo make install
-```
+---
+## Installation
 
-### Installing PCL (compiled with VTK 7.1)
-```
-git clone https://github.com/PointCloudLibrary/pcl.git
-```
-open CMakeLists.txt
-change line 364 from "find_package(VTK)" to  "find_package(VTK 7.1 REQUIRED)"
-```
-cmake .
-make
-sudo make install
-```
+This package depends on PCL 1.8 and VTK 7.1. 
 
+#### Prerequisites
+- **checkinstall**
+    - `sudo apt install checkinstall`
+
+#### Dependencies Installation
+##### 1. VTK
+1. Download [VTK 7.1](https://github.com/Kitware/VTK/releases/tag/v7.1.0)
+2. Unzip or extract into a user accessible directory
+3. `CD` into that directory and create a new `build` directory
+4. Run cmake
+    ```
+    cd build
+    cmake ..
+    ```
+1. Build the library
+    ```
+    make
+    ```
+    _This will take a while ..._
+2. Install 
+    ```
+    sudo checkinstall --pkgname=vtk-7.1
+    ```
+    The installation process will prompt you to accept/reject some options prior to building the debian.
+    NOTE: Using `checkinstall` instead of `make install` has the advantage that it builds a debian package which can be easily uninstalled with `sudo dpkg -r [packagename]`.
+    
+##### 2. PCL 
+1. Download [PCL 1.8](https://github.com/PointCloudLibrary/pcl/releases/tag/pcl-1.8.0)
+2. Unzip or extract into a user accessible directory
+3. `cd` into that directory and locate the `CMakeLists.txt` file.
+4. Locate the `find package(VTK)` line (close to line 362) and edit it to `find_package(VTK 7.1 REQUIRED)`
+5. Configure and build
+    ```
+    cmake .
+    make
+    ```
+    _Wait until the build finishes, it may take a couple of hours ..._
+1. Install 
+    ```
+    sudo checkinstall --pkgname=pcl-1.8
+    ```
+    The installation process will prompt you to accept/reject some options prior to building the debian.
+    NOTE: Using `checkinstall` instead of `make install` has the advantage that it builds a debian package which can be easily uninstalled with `sudo dpkg -r [packagename]`.
+
+---
 ## Build
-TBD
+- Create a catkin workspace and clone this repository in the `src` directory
+- Build the noether packages
+  ```
+  catkin build noether noether_conversions
+  ```
+  
+  _Note: You can just run catkin build in order to build everything in your workspace including the noether packages_
 
-## Test Noether
+## Test Noether (DEPRECATED)
 Run the unit tests for each package:
 catkin_make run_tests_<package-name>
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This package depends on PCL 1.8 and VTK 7.1.
     ```
     sudo checkinstall --pkgname=vtk-7.1
     ```
-    The installation process will prompt you to accept/reject some options prior to building the debian.
+    The installation process will prompt you to accept/reject some options prior to building the debian, **just follow the recommended prompts**.
+    
     NOTE: Using `checkinstall` instead of `make install` has the advantage that it builds a debian package which can be easily uninstalled with `sudo dpkg -r [packagename]`.
     
 ##### 2. PCL 
@@ -53,7 +54,8 @@ This package depends on PCL 1.8 and VTK 7.1.
     ```
     sudo checkinstall --pkgname=pcl-1.8
     ```
-    The installation process will prompt you to accept/reject some options prior to building the debian.
+    The installation process will prompt you to accept/reject some options prior to building the debian, **just follow the recommended prompts**
+    
     NOTE: Using `checkinstall` instead of `make install` has the advantage that it builds a debian package which can be easily uninstalled with `sudo dpkg -r [packagename]`.
 
 ---


### PR DESCRIPTION
The previous installation procedures aren't detailed enough and caused me to install the wrong versions of vtk and pcl.  This change adds more detail to help install the right versions of each major source dependency.