### PR TITLE
Fix the pcl_conversions build issue

### DIFF
--- a/noether/CMakeLists.txt
+++ b/noether/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED cmake_modules
     vtk_viewer
     noether_msgs
     roscpp
+    pcl_conversions
     actionlib
     noether_msgs
     noether_conversions
@@ -25,6 +26,8 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES noether
   CATKIN_DEPENDS
+    roscpp
+    pcl_conversions
     mesh_segmenter
     tool_path_planner
     path_sequence_planner

--- a/noether/package.xml
+++ b/noether/package.xml
@@ -10,6 +10,7 @@
   <depend>catkin</depend>
 
   <depend>roscpp</depend>
+  <depend>pcl_conversions</depend>
   <depend>mesh_segmenter</depend>
   <depend>tool_path_planner</depend>
   <depend>path_sequence_planner</depend>

--- a/noether/src/segmentation_server.cpp
+++ b/noether/src/segmentation_server.cpp
@@ -11,7 +11,6 @@
 #include <vtkWindowedSincPolyDataFilter.h>
 #include <vtkSmoothPolyDataFilter.h>
 
-//#include <noether/noether.h>
 #include <vtk_viewer/vtk_utils.h>
 
 class SegmentationAction

--- a/noether_examples/CMakeLists.txt
+++ b/noether_examples/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED cmake_modules
     vtk_viewer
     noether_msgs
     roscpp
+    pcl_conversions
     roslib
     actionlib
     noether_conversions
@@ -33,6 +34,8 @@ catkin_package(
     noether_msgs
     actionlib
     roslib
+    roscpp
+    pcl_conversions
   DEPENDS VTK
 )
 

--- a/noether_examples/package.xml
+++ b/noether_examples/package.xml
@@ -9,6 +9,7 @@
   <depend>catkin</depend>
 
   <depend>roscpp</depend>
+  <depend>pcl_conversions</depend>
   <depend>mesh_segmenter</depend>
   <depend>tool_path_planner</depend>
   <depend>path_sequence_planner</depend>

--- a/tool_path_planner/CMakeLists.txt
+++ b/tool_path_planner/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 ## Compile as C++14, 
-add_compile_options(-std=c++14)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(tool_path_planner)
 find_package(catkin REQUIRED cmake_modules vtk_viewer rosconsole noether_msgs shape_msgs geometry_msgs eigen_conversions)

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -34,8 +34,7 @@
 #include <vtkGenericCell.h>
 #include <vtkTriangleFilter.h>
 
-
-#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/conversions.h>
 #include <tool_path_planner/utilities.h>
 
 namespace tool_path_planner
@@ -115,9 +114,7 @@ bool convertToPCLMesh(const shape_msgs::Mesh& mesh_msg, pcl::PolygonMesh& mesh)
     return p;
   });
 
-  sensor_msgs::PointCloud2 cloud_msg;
-  pcl::toROSMsg(mesh_points,cloud_msg);
-  pcl_conversions::toPCL(cloud_msg,mesh.cloud);
+  pcl::toPCLPointCloud2(mesh_points,mesh.cloud);
   return true;
 }
 


### PR DESCRIPTION
These changes add the `pcl_conversions` dependency where necessary and removes it when the needed functions are found in `pcl/conversions.h.`  The [pcl_conversions package only contains a header file](https://github.com/ros-perception/perception_pcl/tree/melodic-devel/pcl_conversions) so it should not cause any  runtime issues as far as I know.