### PR TITLE
Adding Debug Guards to Tests

### DIFF
--- a/path_sequence_planner/test/utest.cpp
+++ b/path_sequence_planner/test/utest.cpp
@@ -146,7 +146,13 @@ TEST(IntersectTest, TestCase1)
   color[2] = 0.9;
   viz.addPolyNormalsDisplay(connecting_data, color, 1.0);
 
+  #ifdef NDEBUG
+  // release build stuff goes here
+  // LOGGING_FUNCTION("noether/path_sequence_planner test: visualization is only available in debug mode");
+  #else
+  // Debug-specific code goes here
   viz.renderDisplay();
+  #endif
 }
 
 // Run all the tests that were declared with TEST()

--- a/path_sequence_planner/test/utest.cpp
+++ b/path_sequence_planner/test/utest.cpp
@@ -148,7 +148,7 @@ TEST(IntersectTest, TestCase1)
 
   #ifdef NDEBUG
   // release build stuff goes here
-  // LOGGING_FUNCTION("noether/path_sequence_planner test: visualization is only available in debug mode");
+  LOG4CXX_ERROR(vtk_viewer::VTK_LOGGER,"noether/path_sequence_planner test: visualization is only available in debug mode");
   #else
   // Debug-specific code goes here
   viz.renderDisplay();

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -118,7 +118,7 @@ TEST(IntersectTest, TestCase1)
 
   #ifdef NDEBUG
   // release build stuff goes here
-  // LOGGING_FUNCTION("noether/tool_path_planner test: visualization is only available in debug mode");
+  LOG4CXX_ERROR(tool_path_planner::RasterToolPathPlanner::RASTER_PATH_PLANNER_LOGGER, "noether/tool_path_planner test: visualization is only available in debug mode");
   #else
   // Debug-specific code goes here
   viz.renderDisplay();
@@ -219,7 +219,7 @@ TEST(IntersectTest, TestCaseRansac)
 
   #ifdef NDEBUG
   // release build stuff goes here
-  // LOGGING_FUNCTION("noether/tool_path_planner test: visualization is only available in debug mode");
+  LOG4CXX_ERROR(tool_path_planner::RasterToolPathPlanner::RASTER_PATH_PLANNER_LOGGER, "noether/tool_path_planner test: visualization is only available in debug mode");
   #else
   // Debug-specific code goes here
   viz.renderDisplay();

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -116,7 +116,13 @@ TEST(IntersectTest, TestCase1)
     }
   }
 
+  #ifdef NDEBUG
+  // release build stuff goes here
+  // LOGGING_FUNCTION("noether/tool_path_planner test: visualization is only available in debug mode");
+  #else
+  // Debug-specific code goes here
   viz.renderDisplay();
+  #endif
 }
 
 TEST(IntersectTest, TestCaseRansac)
@@ -211,7 +217,13 @@ TEST(IntersectTest, TestCaseRansac)
     }
   }
 
+  #ifdef NDEBUG
+  // release build stuff goes here
+  // LOGGING_FUNCTION("noether/tool_path_planner test: visualization is only available in debug mode");
+  #else
+  // Debug-specific code goes here
   viz.renderDisplay();
+  #endif
 }
 
 int main(int argc, char **argv)

--- a/vtk_viewer/test/utest.cpp
+++ b/vtk_viewer/test/utest.cpp
@@ -67,7 +67,7 @@ TEST(ViewerTest, TestCase1)
 
   #ifdef NDEBUG
   // release build stuff goes here
-  // LOGGING_FUNCTION("noether/vtk_viewer test: visualization is only available in debug mode");
+  LOG4CXX_ERROR(vtk_viewer::VTK_LOGGER,"noether/vtk_viewer: visualization is only available in debug mode");
   #else
   // Debug-specific code goes here
   viz.renderDisplay();

--- a/vtk_viewer/test/utest.cpp
+++ b/vtk_viewer/test/utest.cpp
@@ -65,8 +65,13 @@ TEST(ViewerTest, TestCase1)
   viz.addPolyDataDisplay(cut,color);
   viz.addPointDataDisplay(cut->GetPoints(), color);
 
+  #ifdef NDEBUG
+  // release build stuff goes here
+  // LOGGING_FUNCTION("noether/vtk_viewer test: visualization is only available in debug mode");
+  #else
+  // Debug-specific code goes here
   viz.renderDisplay();
-
+  #endif
 }
 
 // Run all the tests that were declared with TEST()


### PR DESCRIPTION
- add #ifdef checking whether build is debug or release to tests
  - vtk_viewer
  - tool_path_planner
  - path_sequence_planner
- If built in debug, visualizations will appear for inspection
- If built in release, visualizations will not appear and the tests will terminate without user intervention.
  - this should allow tests to be run by CI