### PR TITLE
Rotate raster direction

### DIFF
--- a/mesh_segmenter/test/utest.cpp
+++ b/mesh_segmenter/test/utest.cpp
@@ -19,7 +19,7 @@ TEST(SegmentationTest, TestCase1)
   double curvature_threshold = 0.2;
 
   // Get mesh - This leaves some holes in it for some reason.
-  vtkSmartPointer<vtkPoints> points = vtk_viewer::createPlane(20, vtk_viewer::SINUSOIDAL_1D);
+  vtkSmartPointer<vtkPoints> points = vtk_viewer::createPlane(20, 20, vtk_viewer::SINUSOIDAL_1D);
   vtkSmartPointer<vtkPolyData> data = vtk_viewer::createMesh(points, 0.25, 7);
 
   // Generate normals

--- a/noether_msgs/msg/ToolPathConfig.msg
+++ b/noether_msgs/msg/ToolPathConfig.msg
@@ -4,3 +4,11 @@ float64 tool_offset 				# How far off the surface the tool needs to be
 float64 intersecting_plane_height 	# Used by the raster_tool_path_planner when offsetting to an adjacent path, a new plane has to be formed, but not too big
 float64 min_hole_size 				# A path may pass over holes smaller than this, but must be broken when larger holes are encounterd. 
 float64 min_segment_size 			# The minimum segment size to allow when finding intersections; small segments will be discarded
+int32 raster_direction                          # Specifies the direction of the raster path wrt to the principal axes
+
+# Options for raster_direction
+int32 MAJOR_AXIS = 0                            # Along the largest axis of the mesh bounding box
+int32 MIDDLE_AXIS = 1                           # Along the 2nd largest axis of the mesh bounding box
+int32 MINOR_AXIS = 2                            # Along the smallest axis of the mesh bounding box
+int32 MAJOR_MIDDLE_45 = 3                       # Halfway in between the major and middle axes
+int32 MAJOR_MIDDLE_NEG45 = 4                    # Halfway in between major and negative middle axes

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -123,7 +123,7 @@ namespace tool_path_planner
      * MAJOR_MIDDLE_NEG45 = Halfway in between major and negative middle axes
      * @param direction The direction used
      */
-    void setRasterDirection(RasterDirection direction) {raster_direction_ = direction;}
+    void setRasterDirection(RasterDirection direction) {tool_.raster_direction = direction;}
 
   private:
     bool debug_on_; /**< Turns on/off the debug display which views the path planning output one step at a time */
@@ -134,9 +134,6 @@ namespace tool_path_planner
     vtkSmartPointer<vtkPolyData> input_mesh_;        /**< input mesh to operate on */
     std::vector<ProcessPath> paths_;                 /**< series of intersecting lines on the given mesh */
     ProcessTool tool_; /**< The tool parameters which defines how to generate the tool paths (spacing, offset, etc.) */
-    RasterDirection raster_direction_ =
-        MAJOR_AXIS; /** @brief sets the direction used for rastering with respect to the mesh's bounding box (assuming
-                       cut_direction is not set to override it)*/
 
     double cut_direction_[3];
     double cut_centroid_[3];

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -101,22 +101,45 @@ namespace tool_path_planner
      */
     std::string getLogDir(){return debug_viewer_.getLogDir();}
 
-    void setCutDirection(double direction [3]);
-    void setCutCentroid(double centroid [3]);
+    /**
+     * @brief Overrides the direction of the raster paths so that paths are generated in the direction of this unit vector
+     * @param direction Unit vector associated with the direction
+     */
+    void setCutDirection(double direction[3]);
+    /**
+     * @brief Overrides the location of the centroid used for generating the first tool path
+     * @param centroid Location for the center of the middle raster line (which is used to generate the entire raster)
+     */
+    void setCutCentroid(double centroid[3]);
+
+    /**
+     * @brief  Sets the direction used for rastering with respect to the mesh's bounding box (assuming setCutDirection is
+     * not set to override it)
+     *
+     * MAJOR_AXIS = along the largest axis of the mesh bounding box
+     * MIDDLE_AXIS = along the 2nd largest axis of the mesh bounding box
+     * MINOR_AXIS = along the smallest axis of the mesh bounding box
+     * MAJOR_MIDDLE_45 = Halfway in between the major and middle axes
+     * MAJOR_MIDDLE_NEG45 = Halfway in between major and negative middle axes
+     * @param direction The direction used
+     */
+    void setRasterDirection(RasterDirection direction) {raster_direction_ = direction;}
 
   private:
+    bool debug_on_; /**< Turns on/off the debug display which views the path planning output one step at a time */
+    vtk_viewer::VTKViewer debug_viewer_;             /**< The vtk viewer for displaying debug output */
+    vtkSmartPointer<vtkKdTreePointLocator> kd_tree_; /**< kd tree for finding nearest neighbor points */
+    vtkSmartPointer<vtkCellLocator> cell_locator_;   /** @brief allows locating closest cell */
+    vtkSmartPointer<vtkModifiedBSPTree> bsp_tree_;   /** @brief use to perform ray casting on the mesh */
+    vtkSmartPointer<vtkPolyData> input_mesh_;        /**< input mesh to operate on */
+    std::vector<ProcessPath> paths_;                 /**< series of intersecting lines on the given mesh */
+    ProcessTool tool_; /**< The tool parameters which defines how to generate the tool paths (spacing, offset, etc.) */
+    RasterDirection raster_direction_ =
+        MAJOR_AXIS; /** @brief sets the direction used for rastering with respect to the mesh's bounding box (assuming
+                       cut_direction is not set to override it)*/
 
-    bool debug_on_;                                   /**< Turns on/off the debug display which views the path planning output one step at a time */
-    vtk_viewer::VTKViewer debug_viewer_;              /**< The vtk viewer for displaying debug output */
-    vtkSmartPointer<vtkKdTreePointLocator> kd_tree_;  /**< kd tree for finding nearest neighbor points */
-    vtkSmartPointer<vtkCellLocator> cell_locator_;    /** @brief allows locating closest cell */
-    vtkSmartPointer<vtkModifiedBSPTree> bsp_tree_;    /** @brief use to perform ray casting on the mesh */
-    vtkSmartPointer<vtkPolyData> input_mesh_;         /**< input mesh to operate on */
-    std::vector<ProcessPath> paths_;                  /**< series of intersecting lines on the given mesh */
-    ProcessTool tool_;                                /**< The tool parameters which defines how to generate the tool paths (spacing, offset, etc.) */
-
-    double cut_direction_ [3];
-    double cut_centroid_ [3];
+    double cut_direction_[3];
+    double cut_centroid_[3];
 
     /**
      * @brief getFirstPath Uses the input mesh, generates the first path by intersecting the mesh with a plane

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -15,6 +15,24 @@
 
 namespace tool_path_planner
 {
+/**
+ * @brief This is used to specify the direction of the raster path generated.
+ *
+ * MAJOR_AXIS = along the largest axis of the mesh bounding box
+ * MIDDLE_AXIS = along the 2nd largest axis of the mesh bounding box
+ * MINOR_AXIS = along the smallest axis of the mesh bounding box
+ * MAJOR_MIDDLE_45 = Halfway in between the major and middle axes
+ * MAJOR_MIDDLE_NEG45 = Halfway in between major and negative middle axes
+ */
+enum RasterDirection
+{
+    MAJOR_AXIS = 0,
+    MIDDLE_AXIS = 1,
+    MINOR_AXIS = 2,
+    MAJOR_MIDDLE_45 = 3,
+    MAJOR_MIDDLE_NEG45 = 4
+};
+
   struct ProcessPath
   {
     vtkSmartPointer<vtkPolyData> line; // sequence of points and a normal defining the locations and z-axis orientation of the tool along the path
@@ -34,25 +52,8 @@ namespace tool_path_planner
                                           are encountered */
     double min_segment_size;          /** The minimum segment size to allow when finding intersections; small segments will
                                           be discarded */
+    RasterDirection raster_direction; /** Specifies the direction of the raster path wrt to the principal axes */
   };
-/**
- * @brief This is used to specify the direction of the raster path generated.
- *
- * MAJOR_AXIS = along the largest axis of the mesh bounding box
- * MIDDLE_AXIS = along the 2nd largest axis of the mesh bounding box
- * MINOR_AXIS = along the smallest axis of the mesh bounding box
- * MAJOR_MIDDLE_45 = Halfway in between the major and middle axes
- * MAJOR_MIDDLE_NEG45 = Halfway in between major and negative middle axes
- */
-enum RasterDirection
-{
-  MAJOR_AXIS,
-  MIDDLE_AXIS,
-  MINOR_AXIS,
-  MAJOR_MIDDLE_45,
-  MAJOR_MIDDLE_NEG45
-};
-
 
   /**
    * @class tool_path_planner::ToolPathPlanner

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -35,6 +35,24 @@ namespace tool_path_planner
     double min_segment_size;          /** The minimum segment size to allow when finding intersections; small segments will
                                           be discarded */
   };
+/**
+ * @brief This is used to specify the direction of the raster path generated.
+ *
+ * MAJOR_AXIS = along the largest axis of the mesh bounding box
+ * MIDDLE_AXIS = along the 2nd largest axis of the mesh bounding box
+ * MINOR_AXIS = along the smallest axis of the mesh bounding box
+ * MAJOR_MIDDLE_45 = Halfway in between the major and middle axes
+ * MAJOR_MIDDLE_NEG45 = Halfway in between major and negative middle axes
+ */
+enum RasterDirection
+{
+  MAJOR_AXIS,
+  MIDDLE_AXIS,
+  MINOR_AXIS,
+  MAJOR_MIDDLE_45,
+  MAJOR_MIDDLE_NEG45
+};
+
 
   /**
    * @class tool_path_planner::ToolPathPlanner

--- a/tool_path_planner/include/tool_path_planner/utilities.h
+++ b/tool_path_planner/include/tool_path_planner/utilities.h
@@ -61,6 +61,13 @@ namespace tool_path_planner
 	 */
 	noether_msgs::ToolPathConfig toTppMsg(const tool_path_planner::ProcessTool& tool_config);
 
+        /**
+         * @brief Returns the magnitude of the vector represented by the array
+         * @param vec double array input vector
+         * @return magnitude of the vector
+         */
+        inline double vectorMag(const double vec[3]) {return sqrt(vec[0]*vec[0] + vec[1]*vec[1] + vec[3]*vec[3]);}
+
 }
 
 

--- a/tool_path_planner/src/raster_tool_path_planner.cpp
+++ b/tool_path_planner/src/raster_tool_path_planner.cpp
@@ -731,7 +731,7 @@ namespace tool_path_planner
     // Create additional points for the starting curve
     double pt[3];
     double raster_axis[3];
-    switch(raster_direction_)
+    switch(tool_.raster_direction)
     {
     case MAJOR_AXIS:
     {

--- a/tool_path_planner/src/raster_tool_path_planner.cpp
+++ b/tool_path_planner/src/raster_tool_path_planner.cpp
@@ -728,19 +728,87 @@ namespace tool_path_planner
         max[2] = (max[2] + mid[2]) * temp_max;
       }
     }
-
-    // Use the max axis to create additional points for the starting curve
+    // Create additional points for the starting curve
     double pt[3];
-    pt[0] = avg_center[0] + max[0];
-    pt[1] = avg_center[1] + max[1];
-    pt[2] = avg_center[2] + max[2];
+    double raster_axis[3];
+    switch(raster_direction_)
+    {
+    case MAJOR_AXIS:
+    {
+        raster_axis[0] = max[0];
+        raster_axis[1] = max[1];
+        raster_axis[2] = max[2];
+        break;
+    }
+    case MIDDLE_AXIS:
+    {
+        raster_axis[0] = mid[0];
+        raster_axis[1] = mid[1];
+        raster_axis[2] = mid[2];
+        break;
+    }
+    case MINOR_AXIS:
+    {
+        raster_axis[0] = min[0];
+        raster_axis[1] = min[1];
+        raster_axis[2] = min[2];
+        break;
+    }
+    case MAJOR_MIDDLE_45:
+    {
+        // Calculate magnitudes to convert inputs to unit vectors
+        double max_mag = vectorMag(max);
+        double mid_mag = vectorMag(mid);
+
+        // This vector would give you rasters from corner to corner of the bounding box if that's ever needed
+        double vec_sum[3] = {max[0]+mid[0], max[1]+mid[1], max[2]+mid[2]};
+        double vec_sum_mag = vectorMag(vec_sum);
+
+        // This gets you a vector 45 degrees between max and mid
+        raster_axis[0] = max[0]/max_mag + mid[0]/mid_mag;
+        raster_axis[1] = max[1]/max_mag + mid[1]/mid_mag;
+        raster_axis[2] = max[2]/max_mag + mid[2]/mid_mag;
+
+        // We now scale it by the magnitude of the vector sum to insure that the result is larger than the bounding box
+        double raster_mag = vectorMag(raster_axis);
+        raster_axis[0] = (raster_axis[0]/raster_mag) * vec_sum_mag;    // ( raster unit vector) * desired magnitude
+        raster_axis[1] = (raster_axis[1]/raster_mag) * vec_sum_mag;
+        raster_axis[2] = (raster_axis[2]/raster_mag) * vec_sum_mag;
+        break;
+    }
+    case MAJOR_MIDDLE_NEG45:
+    {
+        // Calculate magnitudes to convert inputs to unit vectors
+        double max_mag = vectorMag(max);
+        double mid_mag = vectorMag(mid);
+
+        // This vector would give you rasters from corner to corner of the bounding box if that's ever needed
+        double vec_sum[3] = {max[0]-mid[0], max[1]-mid[1], max[2]-mid[2]};
+        double vec_sum_mag = vectorMag(vec_sum);
+
+        // This gets you a vector 45 degrees between max and mid
+        raster_axis[0] = max[0]/max_mag - mid[0]/mid_mag;
+        raster_axis[1] = max[1]/max_mag - mid[1]/mid_mag;
+        raster_axis[2] = max[2]/max_mag - mid[2]/mid_mag;
+
+        // We now scale it by the magnitude of the vector sum to insure that the result is larger than the bounding box
+        double raster_mag = vectorMag(raster_axis);
+        raster_axis[0] = (raster_axis[0]/raster_mag) * vec_sum_mag;    // ( raster unit vector) * desired magnitude
+        raster_axis[1] = (raster_axis[1]/raster_mag) * vec_sum_mag;
+        raster_axis[2] = (raster_axis[2]/raster_mag) * vec_sum_mag;
+        break;
+    }
+    }
+    pt[0] = avg_center[0] + raster_axis[0];
+    pt[1] = avg_center[1] + raster_axis[1];
+    pt[2] = avg_center[2] + raster_axis[2];
     line->GetPoints()->InsertNextPoint(pt);
 
     line->GetPoints()->InsertNextPoint(avg_center);
 
-    pt[0] = avg_center[0] - max[0];
-    pt[1] = avg_center[1] - max[1];
-    pt[2] = avg_center[2] - max[2];
+    pt[0] = avg_center[0] - raster_axis[0];
+    pt[1] = avg_center[1] - raster_axis[1];
+    pt[2] = avg_center[2] - raster_axis[2];
     line->GetPoints()->InsertNextPoint(pt);
 
     // set the normal for all points inserted

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -183,7 +183,8 @@ tool_path_planner::ProcessTool fromTppMsg(const noether_msgs::ToolPathConfig& tp
     .tool_offset = tpp_msg_config.tool_offset,
     .intersecting_plane_height = tpp_msg_config.intersecting_plane_height,
     .min_hole_size = tpp_msg_config.min_hole_size,
-    .min_segment_size = tpp_msg_config.min_segment_size
+    .min_segment_size = tpp_msg_config.min_segment_size,
+    .raster_direction = static_cast<RasterDirection>(tpp_msg_config.raster_direction)
   };
 }
 
@@ -196,6 +197,7 @@ noether_msgs::ToolPathConfig toTppMsg(const tool_path_planner::ProcessTool& tool
   tpp_config_msg.intersecting_plane_height = tool_config.intersecting_plane_height;
   tpp_config_msg.min_hole_size = tool_config.min_hole_size;
   tpp_config_msg.min_segment_size = tool_config.min_segment_size;
+  tpp_config_msg.raster_direction = static_cast<int>(tool_config.raster_direction);
 
   return std::move(tpp_config_msg);
 }

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -60,6 +60,7 @@ TEST(IntersectTest, TestCase1)
   tool.min_hole_size = 0.1;
   planner.setTool(tool);
   planner.setDebugMode(false);
+  planner.setRasterDirection(tool_path_planner::MAJOR_AXIS);
 
   vtk_viewer::VTKViewer viz;
   std::vector<float> color(3);
@@ -224,6 +225,113 @@ TEST(IntersectTest, TestCaseRansac)
   // Debug-specific code goes here
   viz.renderDisplay();
   #endif
+}
+
+TEST(IntersectTest, RasterRotationTest)
+{
+  tool_path_planner::RasterDirection raster_directions[] = { tool_path_planner::MAJOR_AXIS,
+                                                             tool_path_planner::MIDDLE_AXIS,
+                                                             tool_path_planner::MINOR_AXIS,
+                                                             tool_path_planner::MAJOR_MIDDLE_45,
+                                                             tool_path_planner::MAJOR_MIDDLE_NEG45 };
+  for (auto direction : raster_directions)
+  {
+    // Get mesh
+    vtkSmartPointer<vtkPoints> points = vtk_viewer::createPlane(30, 10, vtk_viewer::FLAT);
+    vtkSmartPointer<vtkPolyData> data = vtk_viewer::createMesh(points, 0.5, 5);
+    vtk_viewer::generateNormals(data);
+
+    // create cutout in the middle of the mesh
+    vtkSmartPointer<vtkPoints> points2 = vtkSmartPointer<vtkPoints>::New();
+    double pt1[3] = { 2.0, 3.0, 0.0 };
+    double pt2[3] = { 4.0, 2.0, 0.0 };
+    double pt3[3] = { 5.0, 3.0, 0.0 };
+    double pt4[3] = { 4.0, 5.0, 0.0 };
+    points2->InsertNextPoint(pt1);
+    points2->InsertNextPoint(pt2);
+    points2->InsertNextPoint(pt3);
+    points2->InsertNextPoint(pt4);
+
+    vtkSmartPointer<vtkPolyData> data2 = vtkSmartPointer<vtkPolyData>::New();
+    data2 = vtk_viewer::cutMesh(data, points2, false);
+
+    // Set input mesh
+    tool_path_planner::RasterToolPathPlanner planner;
+    planner.setInputMesh(data2);
+
+    // Set input tool data
+    tool_path_planner::ProcessTool tool;
+    tool.pt_spacing = POINT_SPACING;
+    tool.line_spacing = 0.75;
+    tool.tool_offset = 0.0;                // currently unused
+    tool.intersecting_plane_height = 0.2;  // 0.5 works best, not sure if this should be included in the tool
+    tool.min_hole_size = 0.1;
+    planner.setTool(tool);
+    planner.setDebugMode(false);
+    planner.setRasterDirection(direction);
+
+    vtk_viewer::VTKViewer viz;
+    std::vector<float> color(3);
+
+    double scale = 1.0;
+
+    // Display mesh results
+    color[0] = 0.9;
+    color[1] = 0.9;
+    color[2] = 0.9;
+    viz.addPolyDataDisplay(data2, color);
+
+    // Display surface normals
+    if (DISPLAY_NORMALS)
+    {
+      color[0] = 0.9;
+      color[1] = 0.1;
+      color[2] = 0.1;
+      vtkSmartPointer<vtkPolyData> normals_data = vtkSmartPointer<vtkPolyData>::New();
+      normals_data = planner.getInputMesh();
+      viz.addPolyNormalsDisplay(normals_data, color, scale);
+    }
+
+    // Plan paths for given mesh
+    planner.computePaths();
+    std::vector<tool_path_planner::ProcessPath> paths = planner.getPaths();
+
+    for (int i = 0; i < paths.size(); ++i)
+    {
+      if (DISPLAY_LINES)  // display line
+      {
+        color[0] = 0.2;
+        color[1] = 0.9;
+        color[2] = 0.2;
+        viz.addPolyNormalsDisplay(paths[i].line, color, scale);
+      }
+
+      if (DISPLAY_DERIVATIVES)  // display derivatives
+      {
+        color[0] = 0.9;
+        color[1] = 0.9;
+        color[2] = 0.2;
+        viz.addPolyNormalsDisplay(paths[i].derivatives, color, scale);
+      }
+
+      if (DISPLAY_CUTTING_MESHES)  // Display cutting mesh
+      {
+        color[0] = 0.9;
+        color[1] = 0.9;
+        color[2] = 0.9;
+        viz.addPolyDataDisplay(paths[i].intersection_plane, color);
+      }
+    }
+
+#ifdef NDEBUG
+    // release build stuff goes here
+    LOG4CXX_ERROR(tool_path_planner::RasterToolPathPlanner::RASTER_PATH_PLANNER_LOGGER,
+                  "noether/tool_path_planner test: visualization is only available in debug mode");
+#else
+    // Debug-specific code goes here
+    viz.renderDisplay();
+#endif
+  }
 }
 
 int main(int argc, char **argv)

--- a/vtk_viewer/include/vtk_viewer/vtk_utils.h
+++ b/vtk_viewer/include/vtk_viewer/vtk_utils.h
@@ -46,7 +46,7 @@ namespace vtk_viewer
    * SINUSOIDAL_2D = Sinusoidal in two dimensions
    * @return The points associated with the mesh
    */
-  vtkSmartPointer<vtkPoints> createPlane(unsigned int gridSize = 10, vtk_viewer::plane_type = vtk_viewer::SINUSOIDAL_2D);
+  vtkSmartPointer<vtkPoints> createPlane(unsigned int grid_size_x = 10, unsigned int grid_size_y = 10, vtk_viewer::plane_type = vtk_viewer::SINUSOIDAL_2D);
 
   /**
    * @brief visualizePlane Creates a simple VTK viewer to visualize a mesh object

--- a/vtk_viewer/src/vtk_utils.cpp
+++ b/vtk_viewer/src/vtk_utils.cpp
@@ -68,14 +68,14 @@ namespace vtk_viewer
 {
 log4cxx::LoggerPtr VTK_LOGGER = createConsoleLogger("VTK_VIEWER");
 
-vtkSmartPointer<vtkPoints> createPlane(unsigned int gridSize, vtk_viewer::plane_type type)
+vtkSmartPointer<vtkPoints> createPlane(unsigned int grid_size_x, unsigned int grid_size_y, vtk_viewer::plane_type type)
 {
   // Create points on an XY grid with a sinusoidal Z component
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
 
-  for (unsigned int x = 0; x < gridSize; x++)
+  for (unsigned int x = 0; x < grid_size_x; x++)
   {
-    for (unsigned int y = 0; y < gridSize; y++)
+    for (unsigned int y = 0; y < grid_size_y; y++)
     {
       switch (type)
       {


### PR DESCRIPTION
This pull request adds the ability to raster in a direction other than the Major axis (the longest axis of the bounding box). Before, there was cut_direction_ which could be specified, but this was just a vector in world coordinates. The new RasterDirection parameter allows you to raster along any of the 3 axes of the bounding box as well as 45 degrees between the longest and 2nd longest axis. This is done by adding a switch in createStartCurve().

Run the test to visualize the different types. Note that the first two displayed are from different tests. The last 5 are from this PR. Also, I have commonly had to run the tests more than once to get them to show up. If the meshes are empty, try running it again.
```
catkin run_tests tool_path_planner --no-deps
```

Note: There are 2 known issues with this.
1) When rastering in the -45 degree direction, the normals are reversed. I'm assuming this is an easy fix, but simply multiplying n by -1 in raster_tool_path_planner.cpp line 825 does not seem to fix it.
2) Due to the way the adjacent raster patterns are created, corners of the mesh may not get rastered when not rastering along one of the 3 bounding box axes (see the attached image). As far as I can tell it works like this
* A seed line is generated using the centroid and and bounding box axes
* This line is projected onto the mesh to create the first raster strip
* Each point in that raster strip is used to create an adjacent raster strip

My thinking was that when rotating the raster lines, the first raster strip is no longer that longest. Thus, the corners get cut off in sections where more points are needed than are given in the initial raster strip. However the second image seems to disprove that.




![45 degree raster](https://user-images.githubusercontent.com/12128406/54226416-cbd08100-44cb-11e9-83f8-05883dccc347.png)
![triangle](https://user-images.githubusercontent.com/12128406/54227960-143d6e00-44cf-11e9-921c-36158314e04c.png)
