### PR TITLE
Rotate raster direction

### DIFF
--- a/mesh_segmenter/test/utest.cpp
+++ b/mesh_segmenter/test/utest.cpp
@@ -19,7 +19,7 @@ TEST(SegmentationTest, TestCase1)
   double curvature_threshold = 0.2;
 
   // Get mesh - This leaves some holes in it for some reason.
-  vtkSmartPointer<vtkPoints> points = vtk_viewer::createPlane(20, vtk_viewer::SINUSOIDAL_1D);
+  vtkSmartPointer<vtkPoints> points = vtk_viewer::createPlane(20, 20, vtk_viewer::SINUSOIDAL_1D);
   vtkSmartPointer<vtkPolyData> data = vtk_viewer::createMesh(points, 0.25, 7);
 
   // Generate normals

--- a/noether_msgs/msg/ToolPathConfig.msg
+++ b/noether_msgs/msg/ToolPathConfig.msg
@@ -4,3 +4,5 @@ float64 tool_offset 				# How far off the surface the tool needs to be
 float64 intersecting_plane_height 	# Used by the raster_tool_path_planner when offsetting to an adjacent path, a new plane has to be formed, but not too big
 float64 min_hole_size 				# A path may pass over holes smaller than this, but must be broken when larger holes are encounterd. 
 float64 min_segment_size 			# The minimum segment size to allow when finding intersections; small segments will be discarded
+float64 raster_angle          # Specifies the direction of the raster path in radians
+bool raster_wrt_principal_axis # When true, 0 raster_angle is aligned with the principal axis

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -115,6 +115,19 @@ namespace tool_path_planner
      */
     void setCutCentroid(double centroid[3]);
 
+    /**
+     * @brief Specifies the direction of the rasters wrt either the mesh coordinates or the principal axis. Rotation is in radians. Default is 0.0
+     * @param angle (radians)
+     */
+    void setRasterAngle(double angle) {raster_angle_= angle;}
+
+    /** @brief Specifies axis about which raster_angle_ is applied. Default is true
+     *
+     * If true, raster angle is specified about the smallest axis of the bounding box with 0 being in the direction of the
+     * principal axis. If false (TODO 3/19/2019), the raster angle is about the mesh z coordinate with the x axis being 0. Then the resultant vecotor is projected onto the plane created
+     * by the bounding box x and y axes */
+    void setRasterWRTPrincipalAxis(bool axis) {raster_wrt_principal_axis_ = axis;}
+
   private:
 
     bool debug_on_;                                   /**< Turns on/off the debug display which views the path planning output one step at a time */
@@ -125,6 +138,13 @@ namespace tool_path_planner
     vtkSmartPointer<vtkPolyData> input_mesh_;         /**< input mesh to operate on */
     std::vector<ProcessPath> paths_;                  /**< series of intersecting lines on the given mesh */
     ProcessTool tool_;                                /**< The tool parameters which defines how to generate the tool paths (spacing, offset, etc.) */
+    double raster_angle_ = 0.0;                       /** @brief Specifies the direction of the rasters wrt either the mesh coordinates or the principal axis. Rotation is in radians. Default is 0.0*/
+    /** @brief Specifies axis about which raster_angle_ is applied. Default is true
+     *
+     * If true, raster angle is specified about the smallest axis of the bounding box with 0 being in the direction of the
+     * principal axis. If false, the raster angle is about the mesh z coordinate with the x axis being 0. Then the resultant vecotor is projected onto the plane created
+     * by the bounding box x and y axes */
+    bool raster_wrt_principal_axis_ = true;
 
     double cut_direction_ [3];
     double cut_centroid_ [3];

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -101,8 +101,19 @@ namespace tool_path_planner
      */
     std::string getLogDir(){return debug_viewer_.getLogDir();}
 
-    void setCutDirection(double direction [3]);
-    void setCutCentroid(double centroid [3]);
+    /**
+     * @brief Overrides the direction of the raster paths so that paths are generated in the direction of this unit vector
+     *
+     * Note: This is essentially assigning the axis to use instead of using the principal axis. Giving a vector not in the plane of the mesh
+     * could cause problems.
+     * @param direction Unit vector associated with the direction
+     */
+    void setCutDirection(double direction[3]);
+    /**
+     * @brief Overrides the location of the centroid used for generating the first tool path
+     * @param centroid Location for the center of the middle raster line (which is used to generate the entire raster)
+     */
+    void setCutCentroid(double centroid[3]);
 
   private:
 

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -34,6 +34,8 @@ namespace tool_path_planner
                                           are encountered */
     double min_segment_size;          /** The minimum segment size to allow when finding intersections; small segments will
                                           be discarded */
+    double  raster_angle;             /** Specifies the direction of the raster path wrt to the principal axes */
+    bool raster_wrt_principal_axis;   /** When true, 0 raster_angle is aligned with the principal axis */
   };
 
   /**

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -183,7 +183,9 @@ tool_path_planner::ProcessTool fromTppMsg(const noether_msgs::ToolPathConfig& tp
     .tool_offset = tpp_msg_config.tool_offset,
     .intersecting_plane_height = tpp_msg_config.intersecting_plane_height,
     .min_hole_size = tpp_msg_config.min_hole_size,
-    .min_segment_size = tpp_msg_config.min_segment_size
+    .min_segment_size = tpp_msg_config.min_segment_size,
+    .raster_angle = tpp_msg_config.raster_angle,
+    .raster_wrt_principal_axis = tpp_msg_config.raster_wrt_principal_axis
   };
 }
 
@@ -196,6 +198,8 @@ noether_msgs::ToolPathConfig toTppMsg(const tool_path_planner::ProcessTool& tool
   tpp_config_msg.intersecting_plane_height = tool_config.intersecting_plane_height;
   tpp_config_msg.min_hole_size = tool_config.min_hole_size;
   tpp_config_msg.min_segment_size = tool_config.min_segment_size;
+  tpp_config_msg.raster_angle = tpp_config_msg.raster_angle;
+  tpp_config_msg.raster_wrt_principal_axis = tpp_config_msg.raster_wrt_principal_axis;
 
   return std::move(tpp_config_msg);
 }

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -18,6 +18,112 @@
 #define DISPLAY_CUTTING_MESHES  0
 #define POINT_SPACING 0.5
 
+
+TEST(IntersectTest, RasterRotationTest)
+{
+  double raster_directions[] = {0., 0.78, 1.57, 2.35};
+
+  for (auto direction : raster_directions)
+  {
+    // Get mesh
+    vtkSmartPointer<vtkPoints> points = vtk_viewer::createPlane(30, 10, vtk_viewer::FLAT);
+    vtkSmartPointer<vtkPolyData> data = vtk_viewer::createMesh(points, 0.5, 5);
+    vtk_viewer::generateNormals(data);
+
+    // create cutout in the middle of the mesh
+    vtkSmartPointer<vtkPoints> points2 = vtkSmartPointer<vtkPoints>::New();
+    double pt1[3] = { 2.0, 3.0, 0.0 };
+    double pt2[3] = { 4.0, 2.0, 0.0 };
+    double pt3[3] = { 5.0, 3.0, 0.0 };
+    double pt4[3] = { 4.0, 5.0, 0.0 };
+    points2->InsertNextPoint(pt1);
+    points2->InsertNextPoint(pt2);
+    points2->InsertNextPoint(pt3);
+    points2->InsertNextPoint(pt4);
+
+    vtkSmartPointer<vtkPolyData> data2 = vtkSmartPointer<vtkPolyData>::New();
+    data2 = vtk_viewer::cutMesh(data, points2, false);
+
+    // Set input mesh
+    tool_path_planner::RasterToolPathPlanner planner;
+    planner.setInputMesh(data2);
+
+    // Set input tool data
+    tool_path_planner::ProcessTool tool;
+    tool.pt_spacing = POINT_SPACING;
+    tool.line_spacing = 0.75;
+    tool.tool_offset = 0.0;                // currently unused
+    tool.intersecting_plane_height = 0.2;  // 0.5 works best, not sure if this should be included in the tool
+    tool.min_hole_size = 0.1;
+    planner.setTool(tool);
+    planner.setDebugMode(false);
+    planner.setRasterAngle(direction);
+    planner.setRasterWRTPrincipalAxis(true);
+
+    vtk_viewer::VTKViewer viz;
+    std::vector<float> color(3);
+
+    double scale = 1.0;
+
+    // Display mesh results
+    color[0] = 0.9;
+    color[1] = 0.9;
+    color[2] = 0.9;
+    viz.addPolyDataDisplay(data2, color);
+
+    // Display surface normals
+    if (DISPLAY_NORMALS)
+    {
+      color[0] = 0.9;
+      color[1] = 0.1;
+      color[2] = 0.1;
+      vtkSmartPointer<vtkPolyData> normals_data = vtkSmartPointer<vtkPolyData>::New();
+      normals_data = planner.getInputMesh();
+      viz.addPolyNormalsDisplay(normals_data, color, scale);
+    }
+
+    // Plan paths for given mesh
+    planner.computePaths();
+    std::vector<tool_path_planner::ProcessPath> paths = planner.getPaths();
+
+    for (int i = 0; i < paths.size(); ++i)
+    {
+      if (DISPLAY_LINES)  // display line
+      {
+        color[0] = 0.2;
+        color[1] = 0.9;
+        color[2] = 0.2;
+        viz.addPolyNormalsDisplay(paths[i].line, color, scale);
+      }
+
+      if (DISPLAY_DERIVATIVES)  // display derivatives
+      {
+        color[0] = 0.9;
+        color[1] = 0.9;
+        color[2] = 0.2;
+        viz.addPolyNormalsDisplay(paths[i].derivatives, color, scale);
+      }
+
+      if (DISPLAY_CUTTING_MESHES)  // Display cutting mesh
+      {
+        color[0] = 0.9;
+        color[1] = 0.9;
+        color[2] = 0.9;
+        viz.addPolyDataDisplay(paths[i].intersection_plane, color);
+      }
+    }
+
+#ifdef NDEBUG
+    // release build stuff goes here
+    LOG4CXX_ERROR(tool_path_planner::RasterToolPathPlanner::RASTER_PATH_PLANNER_LOGGER,
+                  "noether/tool_path_planner test: visualization is only available in debug mode");
+#else
+    // Debug-specific code goes here
+    viz.renderDisplay();
+#endif
+  }
+}
+
 // This test shows the results of the tool path planner on a square grid that has a sinusoidal
 // variation in the z axis and a cutout in the middle.  It will generate a series of evenly spaced lines (aprox. equal to line_spacing)
 // with evenly spaced points on each line (aprox. equal to pt_spacing).  Yellow arrows show the direction of

--- a/vtk_viewer/include/vtk_viewer/vtk_utils.h
+++ b/vtk_viewer/include/vtk_viewer/vtk_utils.h
@@ -46,7 +46,7 @@ namespace vtk_viewer
    * SINUSOIDAL_2D = Sinusoidal in two dimensions
    * @return The points associated with the mesh
    */
-  vtkSmartPointer<vtkPoints> createPlane(unsigned int gridSize = 10, vtk_viewer::plane_type = vtk_viewer::SINUSOIDAL_2D);
+  vtkSmartPointer<vtkPoints> createPlane(unsigned int grid_size_x = 10, unsigned int grid_size_y = 10, vtk_viewer::plane_type = vtk_viewer::SINUSOIDAL_2D);
 
   /**
    * @brief visualizePlane Creates a simple VTK viewer to visualize a mesh object

--- a/vtk_viewer/src/vtk_utils.cpp
+++ b/vtk_viewer/src/vtk_utils.cpp
@@ -68,14 +68,14 @@ namespace vtk_viewer
 {
 log4cxx::LoggerPtr VTK_LOGGER = createConsoleLogger("VTK_VIEWER");
 
-vtkSmartPointer<vtkPoints> createPlane(unsigned int gridSize, vtk_viewer::plane_type type)
+vtkSmartPointer<vtkPoints> createPlane(unsigned int grid_size_x, unsigned int grid_size_y, vtk_viewer::plane_type type)
 {
   // Create points on an XY grid with a sinusoidal Z component
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
 
-  for (unsigned int x = 0; x < gridSize; x++)
+  for (unsigned int x = 0; x < grid_size_x; x++)
   {
-    for (unsigned int y = 0; y < gridSize; y++)
+    for (unsigned int y = 0; y < grid_size_y; y++)
     {
       switch (type)
       {


### PR DESCRIPTION
This is a new and improved version of PR #30 

This pull request adds the ability to raster in a direction other than the Major axis (the longest axis of the bounding box). Before, there was cut_direction_ which could be specified, but this was just a vector in world coordinates. The new raster_angle parameters allows you to specify an angle about the vector coming out of the mesh with 0 being in the direction of the principal axis. There is also a flag raster_wrt_principal_axis. When true, the above is true. When false, the idea is that you would specify the angle in world coordinates and then those would be projected onto the surface. This has not yet been implemented.

Run the test to visualize the different types. The first 4 are from this Also, I have commonly had to run the tests more than once to get them to show up. If the meshes are empty, try running it again.

catkin run_tests tool_path_planner --no-deps
Note: There is a known issue with this.

Due to the way the adjacent raster patterns are created, corners of the mesh may not get rastered when not rastering along one of the 3 bounding box axes (see the attached image). As far as I can tell it works like this
A seed line is generated using the centroid and and bounding box axes
This line is projected onto the mesh to create the first raster strip
Each point in that raster strip is used to create an adjacent raster strip
My thinking was that when rotating the raster lines, the first raster strip is no longer that longest. Thus, the corners get cut off in sections where more points are needed than are given in the initial raster strip. However the second image seems to disprove that.

![45 degree raster](https://user-images.githubusercontent.com/12128406/54615385-05553f00-4a2c-11e9-83f3-126dc5dcd746.png)
![triangle](https://user-images.githubusercontent.com/12128406/54615388-071f0280-4a2c-11e9-9f27-288145d99f24.png)

Here's a slightly more interesting picture that shows the same problem. Change FLAT to SINUSOIDAL_1D
![Screenshot from 2019-03-19 09-49-10](https://user-images.githubusercontent.com/12128406/54615523-43eaf980-4a2c-11e9-9c86-c54df5cd447e.png)
And Here's one that shows a possibly related issue.
![Screenshot from 2019-03-19 09-50-43](https://user-images.githubusercontent.com/12128406/54615685-84e30e00-4a2c-11e9-8a26-41b26eb2cae2.png)
