### PR TITLE
Add methods for calculating normals

### DIFF
--- a/noether/src/segmentation_server.cpp
+++ b/noether/src/segmentation_server.cpp
@@ -38,7 +38,7 @@ public:
     double curvature_threshold = goal->segmentation_config.curvature_threshold;
     int min_cluster_size = goal->segmentation_config.min_cluster_size;
     int max_cluster_size = goal->segmentation_config.max_cluster_size;
-    double neighborhood_size = goal->segmentation_config.neighborhood_size;
+    double neighborhood_radius = goal->segmentation_config.neighborhood_radius;
     bool use_mesh_normals = goal->segmentation_config.use_mesh_normals;
 
     auto& cfg = goal->filtering_config;
@@ -61,7 +61,7 @@ public:
     curvature_threshold = (curvature_threshold < 0.0001) ? 0.05 : curvature_threshold;
     min_cluster_size = (min_cluster_size == 0) ? 500 : min_cluster_size;
     max_cluster_size = (max_cluster_size == 0) ? 1000000 : max_cluster_size;
-    neighborhood_size = (neighborhood_size < 0.0001) ? 0.05 : neighborhood_size;
+    neighborhood_radius = (neighborhood_radius < 0.0001) ? 0.05 : neighborhood_radius;
 
     windowed_sinc_iterations = (windowed_sinc_iterations == 0) ? 20 : windowed_sinc_iterations;
     windowed_sinc_pass_band = (windowed_sinc_pass_band < 0.0001) ? 0.1 : windowed_sinc_pass_band;
@@ -76,7 +76,7 @@ public:
     vtkSmartPointer<vtkPolyData> mesh;
     pcl::PolygonMesh input_pcl_mesh;
     pcl_conversions::toPCL(goal->input_mesh, input_pcl_mesh);
-    vtk_viewer::pclEncodeMeshAndNormals(input_pcl_mesh, mesh, neighborhood_size);
+    vtk_viewer::pclEncodeMeshAndNormals(input_pcl_mesh, mesh, neighborhood_radius);
     if (use_mesh_normals)
     {
       ROS_INFO("Embedding Triangle Normals.");

--- a/noether_examples/launch/mesh_segmenter_server_client.launch
+++ b/noether_examples/launch/mesh_segmenter_server_client.launch
@@ -3,6 +3,8 @@
   <arg name="min_cluster_size" default="500"/>
   <arg name="max_cluster_size" default="1000000"/>
   <arg name="curvature_threshold" default="0.05"/>
+  <arg name="neighborhood_size" default="0.05"/>
+  <arg name="use_mesh_normals" default="true"/>
   <arg name="show_individually" default="false"/>
   <arg name="save_outputs" default="false"/>
 
@@ -15,6 +17,8 @@
     <param name="min_cluster_size" value="$(arg min_cluster_size)" type="int" />
     <param name="max_cluster_size" value="$(arg max_cluster_size)" type="int" />
     <param name="curvature_threshold" value="$(arg curvature_threshold)" type="double" />
+    <param name="neighborhood_size" value="$(arg neighborhood_size)" type="double" />
+    <param name="use_mesh_normals" value="$(arg use_mesh_normals)" type="bool" />
     <param name="show_individually" value="$(arg show_individually)" type="bool" />
     <param name="save_outputs" value="$(arg save_outputs)" type="bool" />
   </node>

--- a/noether_examples/src/mesh_segmenter_client.cpp
+++ b/noether_examples/src/mesh_segmenter_client.cpp
@@ -78,13 +78,15 @@ int main(int argc, char** argv)
 
   // Step 1: Load parameters
   std::string file;
-  double curvature_threshold;
+  double curvature_threshold, neighborhood_size;
   int min_cluster_size, max_cluster_size;
-  bool show_individually, save_outputs;
+  bool show_individually, save_outputs, use_mesh_normals;
   pnh.param<std::string>("filename", file, "");
   pnh.param<int>("min_cluster_size", min_cluster_size, 500);
   pnh.param<int>("max_cluster_size", max_cluster_size, 1000000);
   pnh.param<double>("curvature_threshold", curvature_threshold, 0.3);
+  pnh.param<double>("neighborhood_size", neighborhood_size, 0.05);
+  pnh.param<bool>("use_mesh_normals", use_mesh_normals, true);
   pnh.param<bool>("show_individually", show_individually, false);
   pnh.param<bool>("save_outputs", save_outputs, false);
 
@@ -111,6 +113,8 @@ int main(int argc, char** argv)
   msg.segmentation_config.max_cluster_size = max_cluster_size;
   msg.segmentation_config.min_cluster_size = min_cluster_size;
   msg.segmentation_config.curvature_threshold = curvature_threshold;
+  msg.segmentation_config.neighborhood_size = neighborhood_size;
+  msg.segmentation_config.use_mesh_normals = use_mesh_normals;
   msg.filtering_config.enable_filtering = true;
   msg.filtering_config.windowed_sinc_iterations = 20;
   ros::Time tStart = ros::Time::now();

--- a/noether_examples/src/mesh_segmenter_client.cpp
+++ b/noether_examples/src/mesh_segmenter_client.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv)
   msg.segmentation_config.max_cluster_size = max_cluster_size;
   msg.segmentation_config.min_cluster_size = min_cluster_size;
   msg.segmentation_config.curvature_threshold = curvature_threshold;
-  msg.segmentation_config.neighborhood_size = neighborhood_size;
+  msg.segmentation_config.neighborhood_radius = neighborhood_size;
   msg.segmentation_config.use_mesh_normals = use_mesh_normals;
   msg.filtering_config.enable_filtering = true;
   msg.filtering_config.windowed_sinc_iterations = 20;

--- a/noether_msgs/msg/SegmentationConfig.msg
+++ b/noether_msgs/msg/SegmentationConfig.msg
@@ -1,6 +1,6 @@
 int32 min_cluster_size 				# The minimum number of cells (triangles) allowed in a segment
 int32 max_cluster_size  				# The maximum number of cells (triangles) allowed in a segment (currently unimplemented 1/10/19)
 float64 curvature_threshold                     # The desired threshold for "nearness" in radians
-float64 neighborhood_size         # Radius used by MLS to calculate point normals.
+float64 neighborhood_radius         # Radius used by MLS to calculate point normals.
 bool use_mesh_normals             # If true, segmentation is based off of the normals defined by each triangle vertex via the right hand rule. If false, normals are calculated using neighborhood size
 

--- a/noether_msgs/msg/SegmentationConfig.msg
+++ b/noether_msgs/msg/SegmentationConfig.msg
@@ -1,3 +1,6 @@
 int32 min_cluster_size 				# The minimum number of cells (triangles) allowed in a segment
 int32 max_cluster_size  				# The maximum number of cells (triangles) allowed in a segment (currently unimplemented 1/10/19)
 float64 curvature_threshold                     # The desired threshold for "nearness" in radians
+float64 neighborhood_size         # Radius used by MLS to calculate point normals.
+bool use_mesh_normals             # If true, segmentation is based off of the normals defined by each triangle vertex via the right hand rule. If false, normals are calculated using neighborhood size
+

--- a/vtk_viewer/include/vtk_viewer/vtk_utils.h
+++ b/vtk_viewer/include/vtk_viewer/vtk_utils.h
@@ -91,8 +91,9 @@ namespace vtk_viewer
    * This is as opposed to generateNormals which takes the cell point normals, averages them, and uses that average as the cell normal
    * Note: This does assume that the mesh is formed correctly with uniformly oriented normals. If not, use something like Meshlab to fix it.
    * @param data The input mesh to operate. When this function returns, the normals will be embedded.
+   * @return true if successful.
    */
-  void embedRightHandRuleNormals(vtkSmartPointer<vtkPolyData>& data);
+  bool embedRightHandRuleNormals(vtkSmartPointer<vtkPolyData>& data);
 
   /**
    * @brief generateNormals Generate point and cell (surface) normals (in place)

--- a/vtk_viewer/include/vtk_viewer/vtk_utils.h
+++ b/vtk_viewer/include/vtk_viewer/vtk_utils.h
@@ -86,6 +86,15 @@ namespace vtk_viewer
   vtkSmartPointer<vtkPolyData> estimateCurvature(vtkSmartPointer<vtkPolyData> mesh, int method);
 
   /**
+   * @brief embedRightHandRuleNormals Embeds the Polydata cells with the normals generated from the right hand rule
+   *
+   * This is as opposed to generateNormals which takes the cell point normals, averages them, and uses that average as the cell normal
+   * Note: This does assume that the mesh is formed correctly with uniformly oriented normals. If not, use something like Meshlab to fix it.
+   * @param data The input mesh to operate. When this function returns, the normals will be embedded.
+   */
+  void embedRightHandRuleNormals(vtkSmartPointer<vtkPolyData>& data);
+
+  /**
    * @brief generateNormals Generate point and cell (surface) normals (in place)
    * @param data The mesh to generate and add normals to
    */

--- a/vtk_viewer/src/vtk_utils.cpp
+++ b/vtk_viewer/src/vtk_utils.cpp
@@ -404,6 +404,9 @@ bool embedRightHandRuleNormals(vtkSmartPointer<vtkPolyData>& data)
   cell_normals->SetNumberOfComponents(3);
   cell_normals->SetNumberOfTuples(size);
 
+  // Counter for cells that are malformed
+  unsigned long bad_cells = 0;
+
   // loop through all cells and add cell normals
   for (int i = 0; i < size; ++i)
   {
@@ -466,11 +469,14 @@ bool embedRightHandRuleNormals(vtkSmartPointer<vtkPolyData>& data)
       }
       else
       {
-        LOG4CXX_ERROR(VTK_LOGGER, "Could not embed normals");
+        bad_cells++;
         success = false;
       }
     }
   }
+  if (bad_cells > 0)
+    LOG4CXX_ERROR(VTK_LOGGER, "Could not embed normals on " << bad_cells << "cells");
+
   // We have looped over every cell. Now embed the normals
   data->GetCellData()->SetNormals(cell_normals);
   return success;

--- a/vtk_viewer/src/vtk_utils.cpp
+++ b/vtk_viewer/src/vtk_utils.cpp
@@ -394,6 +394,67 @@ vtkSmartPointer<vtkPolyData> estimateCurvature(vtkSmartPointer<vtkPolyData> mesh
   return curvature_filter->GetOutput();
 }
 
+void embedRightHandRuleNormals(vtkSmartPointer<vtkPolyData>& data)
+{
+  LOG4CXX_DEBUG(VTK_LOGGER, "Embedding mesh normals from right hand rule");
+  int size = data->GetNumberOfCells();
+  vtkDoubleArray* cell_normals = vtkDoubleArray::New();
+
+  cell_normals->SetNumberOfComponents(3);
+  cell_normals->SetNumberOfTuples(size);
+
+  // loop through all cells and add cell normals
+  for (int i = 0; i < size; ++i)
+  {
+    vtkCell* cell = data->GetCell(i);
+    if (cell)
+    {
+      // Get all point IDs associated with the given cell
+      vtkIdList* pts = cell->GetPointIds();
+      double norm[3] = { 0, 0, 0 };
+
+      // If there are at least 3 points associated with the cell
+      if (pts->GetNumberOfIds() >= 3)
+      {
+        // Define arrays to store the points
+        double p0[3] = { 1, 0, 0 };
+        double p1[3] = { 0, 1, 0 };
+        double p2[3] = { 0, 0, 1 };
+
+        // Extract points from polydata that are associated with this cell
+        data->GetPoint(pts->GetId(0), p0);
+        data->GetPoint(pts->GetId(1), p1);
+        data->GetPoint(pts->GetId(2), p2);
+
+        // Get vectors obeying RHR
+        double v1[3];
+        double v2[3];
+        for (int ind = 0; ind < 3; ind++)
+        {
+          v1[ind] = p1[ind] - p0[ind];
+          v2[ind] = p2[ind] - p1[ind];
+        }
+        // Normal is v1 x v2
+        norm[0] = v1[1] * v2[2] - v2[1] * v1[2];
+        norm[1] = -1 * (v1[0] * v2[2] - v2[0] * v1[2]);
+        norm[2] = v1[0] * v2[1] - v2[0] * v1[1];
+
+        // Normalize the normals
+        vtkMath::Normalize(norm);
+
+        // set the normal for the given cell
+        cell_normals->SetTuple(i, norm);
+      }
+      else
+      {
+        LOG4CXX_ERROR(VTK_LOGGER, "Could not embed normals");
+      }
+    }
+  }
+  // We have looped over every cell. Now embed the normals
+  data->GetCellData()->SetNormals(cell_normals);
+}
+
 void generateNormals(vtkSmartPointer<vtkPolyData>& data, int flip_normals)
 {
   // If point data exists but cell data does not, iterate through the cells and generate normals manually


### PR DESCRIPTION
This PR adds the option to use the normals defined by the triangle of the input mesh defined by the right hand rule. 

Currently for segmentation the normals are calculated by using MLS on the points, then averaging the point normals for each point in a cell to get the cell normals. This has the advantage of not requiring that the mesh have correctly oriented faces, but you can end up with normals that look like this. As you can see, the bottom side of the mesh is inside the MLS radius. Further, the MLS implementation we are using specifies a fixed viewpoint, so the bottom normals are facing up instead of out.

![Screenshot from 2019-03-20 10-01-40](https://user-images.githubusercontent.com/12128406/54714572-3a8e8980-4b1f-11e9-81b0-f9a638579aa7.png)

Since in many cases we know the origin of the mesh and can guarantee that it will be clean, we can just use the triangle normals directly. This is also useful in that if it looks "good" in meshlab, it should look "good" to segmentation. Here are the results using that method.

![Screenshot from 2019-03-20 14-09-20](https://user-images.githubusercontent.com/12128406/54714574-3bbfb680-4b1f-11e9-91a4-650a8c2d9883.png)

I added a function to vtk_utils that calculates these normals and added a switch the segmentation server that allows the user to specify whether it should use the mesh normals or calculate them as before. The default is calculating them as before.