### PR TITLE
Fix rotate raster in ROS action

### DIFF
--- a/noether/src/surface_raster_planner_server.cpp
+++ b/noether/src/surface_raster_planner_server.cpp
@@ -60,7 +60,7 @@ protected:
       if(goal->path_configs.empty())
       {
         ROS_WARN("Path configuration array is empty, using default values");
-        tpp_configs.resize(goal->surface_meshes.size(),toTppMsg(RasterPathGenerator::generateDeaultToolConfig()));
+        tpp_configs.resize(goal->surface_meshes.size(),toTppMsg(RasterPathGenerator::generateDefaultToolConfig()));
       }
       else
       {

--- a/tool_path_planner/include/tool_path_planner/raster_path_generator.h
+++ b/tool_path_planner/include/tool_path_planner/raster_path_generator.h
@@ -55,7 +55,7 @@ public:
 	 * @brief Generates a ProcessTool configuration structure with default parameters filled in.
 	 * @return  The ProcessTool structure.
 	 */
-	static tool_path_planner::ProcessTool generateDeaultToolConfig();
+  static tool_path_planner::ProcessTool generateDefaultToolConfig();
 
 
 };

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -119,14 +119,14 @@ namespace tool_path_planner
      * @brief Specifies the direction of the rasters wrt either the mesh coordinates or the principal axis. Rotation is in radians. Default is 0.0
      * @param angle (radians)
      */
-    void setRasterAngle(double angle) {raster_angle_= angle;}
+    void setRasterAngle(double angle) {tool_.raster_angle= angle;}
 
     /** @brief Specifies axis about which raster_angle_ is applied. Default is true
      *
      * If true, raster angle is specified about the smallest axis of the bounding box with 0 being in the direction of the
      * principal axis. If false (TODO 3/19/2019), the raster angle is about the mesh z coordinate with the x axis being 0. Then the resultant vecotor is projected onto the plane created
      * by the bounding box x and y axes */
-    void setRasterWRTPrincipalAxis(bool axis) {raster_wrt_principal_axis_ = axis;}
+    void setRasterWRTPrincipalAxis(bool axis) {tool_.raster_wrt_principal_axis = axis;}
 
   private:
 
@@ -138,13 +138,6 @@ namespace tool_path_planner
     vtkSmartPointer<vtkPolyData> input_mesh_;         /**< input mesh to operate on */
     std::vector<ProcessPath> paths_;                  /**< series of intersecting lines on the given mesh */
     ProcessTool tool_;                                /**< The tool parameters which defines how to generate the tool paths (spacing, offset, etc.) */
-    double raster_angle_ = 0.0;                       /** @brief Specifies the direction of the rasters wrt either the mesh coordinates or the principal axis. Rotation is in radians. Default is 0.0*/
-    /** @brief Specifies axis about which raster_angle_ is applied. Default is true
-     *
-     * If true, raster angle is specified about the smallest axis of the bounding box with 0 being in the direction of the
-     * principal axis. If false, the raster angle is about the mesh z coordinate with the x axis being 0. Then the resultant vecotor is projected onto the plane created
-     * by the bounding box x and y axes */
-    bool raster_wrt_principal_axis_ = true;
 
     double cut_direction_ [3];
     double cut_centroid_ [3];

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -34,8 +34,14 @@ namespace tool_path_planner
                                           are encountered */
     double min_segment_size;          /** The minimum segment size to allow when finding intersections; small segments will
                                           be discarded */
-    double  raster_angle;             /** Specifies the direction of the raster path wrt to the principal axes */
-    bool raster_wrt_principal_axis;   /** When true, 0 raster_angle is aligned with the principal axis */
+     /** @brief Specifies the direction of the rasters wrt either the mesh coordinates or the principal axis. Rotation is in radians. Default is 0.0*/
+    double  raster_angle;
+    /** @brief Specifies axis about which raster_angle_ is applied. Default is true
+     *
+     * If true, raster angle is specified about the smallest axis of the bounding box with 0 being in the direction of the
+     * principal axis. If false, the raster angle is about the mesh z coordinate with the x axis being 0. Then the resultant vecotor is projected onto the plane created
+     * by the bounding box x and y axes */
+    bool raster_wrt_principal_axis;
   };
 
   /**

--- a/tool_path_planner/src/raster_path_generator.cpp
+++ b/tool_path_planner/src/raster_path_generator.cpp
@@ -275,7 +275,7 @@ RasterPathGenerator::~RasterPathGenerator()
 
 }
 
-tool_path_planner::ProcessTool RasterPathGenerator::generateDeaultToolConfig()
+tool_path_planner::ProcessTool RasterPathGenerator::generateDefaultToolConfig()
 {
   tool_path_planner::ProcessTool tool;
   tool.pt_spacing = 0.01;
@@ -283,6 +283,8 @@ tool_path_planner::ProcessTool RasterPathGenerator::generateDeaultToolConfig()
   tool.tool_offset = 0.0; // currently unused
   tool.intersecting_plane_height = 0.5; // 0.5 works best, not sure if this should be included in the tool
   tool.min_hole_size = 0.01;
+  tool.raster_angle = 0.0;
+  tool.raster_wrt_principal_axis = true;
   return tool;
 }
 

--- a/tool_path_planner/src/raster_tool_path_planner.cpp
+++ b/tool_path_planner/src/raster_tool_path_planner.cpp
@@ -731,14 +731,14 @@ namespace tool_path_planner
     // Create additional points for the starting curve
     double pt[3];
     double raster_axis[3];
-    if (raster_wrt_principal_axis_)
+    if (tool_.raster_wrt_principal_axis)
     {
       // Principal axis is longest axis of the bounding box
       Eigen::Vector3d principal_axis(max);
       Eigen::Vector3d rotation_axis(min);
       rotation_axis.normalize();
       // Form rotation by specified angle about smallest axis of the bounding box
-      Eigen::Quaterniond rot(Eigen::AngleAxisd(raster_angle_, Eigen::Vector3d(rotation_axis)));
+      Eigen::Quaterniond rot(Eigen::AngleAxisd(tool_.raster_angle, Eigen::Vector3d(rotation_axis)));
       rot.normalize();
       // Rotate principal axis by quaternion to get raster axis
       Eigen::Vector3d raster_axis_eigen = rot.toRotationMatrix() * principal_axis;


### PR DESCRIPTION
I had previously added the raster angle to the RasterToolPathPlanner, but since it is already in the ProcessTool that is not needed. As a result, the action interface did not pass the raster angle through. This fixes that.