### PR TITLE
Refactoring: Making Old Initial-Cut-Generation Behavior the Default

### DIFF
--- a/noether/config/tool.yaml
+++ b/noether/config/tool.yaml
@@ -4,6 +4,8 @@ tool_offset: 0.0 # currently unused
 intersecting_plane_height: 0.1 # 0.5 works best, not sure if this should be included in the tool
 min_hole_size: 0.01
 min_segment_size: 0.01
+raster_angle: 0.0
+raster_wrt_global_axes: false
 #cut_norm_x: -8.0
 #cut_norm_y: 0.0
 #cut_norm_z: 0.0

--- a/noether/src/surface_raster_planner_application.cpp
+++ b/noether/src/surface_raster_planner_application.cpp
@@ -112,6 +112,8 @@ tool_path_planner::ProcessTool loadTool(ros::NodeHandle& nh)
   nh.param<double>("intersecting_plane_height", tool.intersecting_plane_height, 0.05);
   nh.param<double>("min_hole_size", tool.min_hole_size, 0.01);
   nh.param<double>("min_segment_size", tool.min_segment_size, 0.01);
+  nh.param<double>("raster_angle", tool.raster_angle, 0.0);
+  nh.param<bool>("raster_wrt_global_axes", tool.raster_wrt_global_axes, false);
 
   return tool;
 }

--- a/noether_msgs/msg/ToolPathConfig.msg
+++ b/noether_msgs/msg/ToolPathConfig.msg
@@ -5,4 +5,11 @@ float64 intersecting_plane_height 	# Used by the raster_tool_path_planner when o
 float64 min_hole_size 				# A path may pass over holes smaller than this, but must be broken when larger holes are encounterd. 
 float64 min_segment_size 			# The minimum segment size to allow when finding intersections; small segments will be discarded
 float64 raster_angle          # Specifies the direction of the raster path in radians
-bool raster_wrt_principal_axis # When true, 0 raster_angle is aligned with the principal axis
+
+# When set to TRUE: initial cuts are determined using the axes of the
+# coordinate frame in which the mesh is placed.  This may cause the
+# initial cut to miss the part.
+# When set to FALSE: initial cuts are determined using the centroid and
+# principal axes of the part.  This is the old default behavior.  (Note
+# that ROS sets message fields to 0/False by default.)
+bool raster_wrt_global_axes

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -123,10 +123,13 @@ namespace tool_path_planner
 
     /** @brief Specifies axis about which raster_angle_ is applied. Default is true
      *
-     * If true, raster angle is specified about the smallest axis of the bounding box with 0 being in the direction of the
-     * principal axis. If false (TODO 3/19/2019), the raster angle is about the mesh z coordinate with the x axis being 0. Then the resultant vecotor is projected onto the plane created
-     * by the bounding box x and y axes */
-    void setRasterWRTPrincipalAxis(bool axis) {tool_.raster_wrt_principal_axis = axis;}
+     * If false, raster angle is specified about the smallest axis of the
+     * bounding box with 0 being in the direction of the principal axis.
+     * If true, the raster angle is about the mesh z
+     * coordinate with the x axis being 0. Then the resultant vecotor is
+     * projected onto the plane created by the bounding box x and y axes
+     */
+    void setRasterWRTPrincipalAxis(bool axis) {tool_.raster_wrt_global_axes = axis;}
 
   private:
 

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -36,12 +36,16 @@ namespace tool_path_planner
                                           be discarded */
      /** @brief Specifies the direction of the rasters wrt either the mesh coordinates or the principal axis. Rotation is in radians. Default is 0.0*/
     double  raster_angle;
-    /** @brief Specifies axis about which raster_angle_ is applied. Default is true
+
+    /** @brief Specifies axis about which raster_angle_ is applied.
      *
-     * If true, raster angle is specified about the smallest axis of the bounding box with 0 being in the direction of the
-     * principal axis. If false, the raster angle is about the mesh z coordinate with the x axis being 0. Then the resultant vecotor is projected onto the plane created
-     * by the bounding box x and y axes */
-    bool raster_wrt_principal_axis;
+     * If false, raster angle is specified about the smallest axis of the
+     * bounding box with 0 being in the direction of the principal axis.
+     *
+     * If true, the raster angle is about the mesh z coordinate with the x
+     * axis being 0. Then the resultant vector is projected onto the plane
+     * created by the bounding box x and y axes */
+    bool raster_wrt_global_axes;
   };
 
   /**

--- a/tool_path_planner/src/raster_path_generator.cpp
+++ b/tool_path_planner/src/raster_path_generator.cpp
@@ -286,7 +286,7 @@ tool_path_planner::ProcessTool RasterPathGenerator::generateDefaultToolConfig()
   tool.intersecting_plane_height = 0.5; // 0.5 works best, not sure if this should be included in the tool
   tool.min_hole_size = 0.01;
   tool.raster_angle = 0.0;
-  tool.raster_wrt_principal_axis = true;
+  tool.raster_wrt_global_axes = false;
   return tool;
 }
 

--- a/tool_path_planner/src/raster_tool_path_planner.cpp
+++ b/tool_path_planner/src/raster_tool_path_planner.cpp
@@ -731,7 +731,7 @@ namespace tool_path_planner
     // Create additional points for the starting curve
     double pt[3];
     double raster_axis[3];
-    if (tool_.raster_wrt_principal_axis)
+    if (!tool_.raster_wrt_global_axes)
     {
       // Principal axis is longest axis of the bounding box
       Eigen::Vector3d principal_axis(max);

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -185,7 +185,7 @@ tool_path_planner::ProcessTool fromTppMsg(const noether_msgs::ToolPathConfig& tp
     .min_hole_size = tpp_msg_config.min_hole_size,
     .min_segment_size = tpp_msg_config.min_segment_size,
     .raster_angle = tpp_msg_config.raster_angle,
-    .raster_wrt_principal_axis = tpp_msg_config.raster_wrt_principal_axis
+    .raster_wrt_global_axes = tpp_msg_config.raster_wrt_global_axes
   };
 }
 
@@ -199,7 +199,7 @@ noether_msgs::ToolPathConfig toTppMsg(const tool_path_planner::ProcessTool& tool
   tpp_config_msg.min_hole_size = tool_config.min_hole_size;
   tpp_config_msg.min_segment_size = tool_config.min_segment_size;
   tpp_config_msg.raster_angle = tpp_config_msg.raster_angle;
-  tpp_config_msg.raster_wrt_principal_axis = tpp_config_msg.raster_wrt_principal_axis;
+  tpp_config_msg.raster_wrt_global_axes = tpp_config_msg.raster_wrt_global_axes;
 
   return std::move(tpp_config_msg);
 }


### PR DESCRIPTION
When the ability to rotate the raster direction was added in PR 31, there were two parameters added to the ProcessTool struct and the corresponding ToolPathConfig message type.  The first one was the raster angle.  The second one was a flag to switch between rotating about one of the principal axes and rotating about the mesh's coordinate frame axes.  As indicated in the documentation for the ProcessTool struct, the intent was for this flag to default to true (principal axis).  Unfortunately, ROS messages fill booleans with false (coordinate axis) by default.

This caused previously written code using the action server to subtly change without notice.  Some meshes would not be affected, while some would now fail to generate an initial intersection.

This commit refactors the 'raster_wrt_principal_axis' field to be 'raster_wrt_global_axes', as well as adjusting the places that this code is called in the rest of the library.  This will ensure that, as intended, using principal axes is the default in both the struct and the ROS message.