### PR TITLE
Feature/extra strokes

### DIFF
--- a/noether_msgs/msg/ToolPathConfig.msg
+++ b/noether_msgs/msg/ToolPathConfig.msg
@@ -13,3 +13,5 @@ float64 raster_angle          # Specifies the direction of the raster path in ra
 # principal axes of the part.  This is the old default behavior.  (Note
 # that ROS sets message fields to 0/False by default.)
 bool raster_wrt_global_axes
+
+bool generate_extra_rasters   # Whether an extra raster stroke should be added to the beginning and end of the raster pattern

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -162,6 +162,16 @@ namespace tool_path_planner
     bool getNextPath(const ProcessPath this_path, ProcessPath& next_path, double dist = 0.0,
                      bool test_self_intersection = true);
 
+    /**
+     * @brief getExtraPath - Using the last path generated, creates and
+     * places an extra path that does not need to intersect with the part
+     * @param last_path - input - the last valid path
+     * @param extra_path - output - a path that may lie beyond the edge of the part
+     * @param dist - input - the distance to offset the next path from the current
+     * @return True if path is successfully created, False if no path can be generated
+     */
+    bool getExtraPath(const ProcessPath& last_path, ProcessPath& extra_path, double dist = 0.0);
+
 
     /**
      * @brief Estimates the normals of a line that lies on the surface of the current mesh.  For each point, it uses the normal of

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -121,7 +121,7 @@ namespace tool_path_planner
      */
     void setRasterAngle(double angle) {tool_.raster_angle= angle;}
 
-    /** @brief Specifies axis about which raster_angle_ is applied. Default is true
+    /** @brief Specifies axis about which raster_angle_ is applied.
      *
      * If false, raster angle is specified about the smallest axis of the
      * bounding box with 0 being in the direction of the principal axis.
@@ -129,7 +129,7 @@ namespace tool_path_planner
      * coordinate with the x axis being 0. Then the resultant vecotor is
      * projected onto the plane created by the bounding box x and y axes
      */
-    void setRasterWRTPrincipalAxis(bool axis) {tool_.raster_wrt_global_axes = axis;}
+    void setRasterWRTGlobalAxis(bool axis) {tool_.raster_wrt_global_axes = axis;}
 
   private:
 

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -34,6 +34,7 @@ namespace tool_path_planner
                                           are encountered */
     double min_segment_size;          /** The minimum segment size to allow when finding intersections; small segments will
                                           be discarded */
+
      /** @brief Specifies the direction of the rasters wrt either the mesh coordinates or the principal axis. Rotation is in radians. Default is 0.0*/
     double  raster_angle;
 
@@ -46,6 +47,8 @@ namespace tool_path_planner
      * axis being 0. Then the resultant vector is projected onto the plane
      * created by the bounding box x and y axes */
     bool raster_wrt_global_axes;
+
+    bool generate_extra_rasters;      /** Whether an extra path should be added to the beginning and end of the raster pattern */
   };
 
   /**

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -48,7 +48,7 @@ namespace tool_path_planner
      * created by the bounding box x and y axes */
     bool raster_wrt_global_axes;
 
-    bool generate_extra_rasters;      /** Whether an extra path should be added to the beginning and end of the raster pattern */
+    bool generate_extra_rasters = false;      /** Whether an extra path should be added to the beginning and end of the raster pattern */
   };
 
   /**

--- a/tool_path_planner/src/raster_tool_path_planner.cpp
+++ b/tool_path_planner/src/raster_tool_path_planner.cpp
@@ -222,6 +222,13 @@ namespace tool_path_planner
       ++count;
     }
 
+    // If requested, generate one extra path extending past the edge of the part
+    if (tool_.generate_extra_rasters == true)
+    {
+      ProcessPath path2;
+      getExtraPath(paths_.back(), path2, tool_.line_spacing);
+    }
+
     // From existing cutting plane, create more offset planes in opposite direction
     count = 0;
     done = false;
@@ -238,6 +245,13 @@ namespace tool_path_planner
       }
 
       ++count;
+    }
+
+    // If requested, generate one extra path extending past the edge of the part
+    if (tool_.generate_extra_rasters == true)
+    {
+      ProcessPath path2;
+      getExtraPath(paths_.back(), path2, -1.0*tool_.line_spacing);
     }
 
     // clear all but the first (mesh) display
@@ -503,6 +517,12 @@ namespace tool_path_planner
       debug_viewer_.renderDisplay();
     }
 
+    return true;
+  }
+
+  bool RasterToolPathPlanner::getExtraPath(const ProcessPath& last_path, ProcessPath& extra_path, double dist)
+  {
+    LOG4CXX_WARN(RASTER_PATH_PLANNER_LOGGER, "getExtraPath not yet implemented");
     return true;
   }
 

--- a/tool_path_planner/src/raster_tool_path_planner.cpp
+++ b/tool_path_planner/src/raster_tool_path_planner.cpp
@@ -562,6 +562,13 @@ namespace tool_path_planner
     // Make sure the spline is using the new points
     extra_path.spline = vtkSmartPointer<vtkParametricSpline>::New();
     extra_path.spline->SetPoints(extra_path.derivatives->GetPoints());
+    vtkSmartPointer<vtkPolyData> points = vtkSmartPointer<vtkPolyData>::New();
+    vtkSmartPointer<vtkPolyData> derivatives = vtkSmartPointer<vtkPolyData>::New();
+    smoothData(extra_path.spline, points, derivatives);
+
+    // Use the points, normals, and derivatives calculated from the spline
+    extra_path.line = points;
+    extra_path.derivatives = derivatives;
 
     return true;
   }

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -185,7 +185,8 @@ tool_path_planner::ProcessTool fromTppMsg(const noether_msgs::ToolPathConfig& tp
     .min_hole_size = tpp_msg_config.min_hole_size,
     .min_segment_size = tpp_msg_config.min_segment_size,
     .raster_angle = tpp_msg_config.raster_angle,
-    .raster_wrt_global_axes = tpp_msg_config.raster_wrt_global_axes
+    .raster_wrt_global_axes = tpp_msg_config.raster_wrt_global_axes,
+    .generate_extra_rasters = tpp_msg_config.generate_extra_rasters
   };
 }
 
@@ -198,8 +199,9 @@ noether_msgs::ToolPathConfig toTppMsg(const tool_path_planner::ProcessTool& tool
   tpp_config_msg.intersecting_plane_height = tool_config.intersecting_plane_height;
   tpp_config_msg.min_hole_size = tool_config.min_hole_size;
   tpp_config_msg.min_segment_size = tool_config.min_segment_size;
-  tpp_config_msg.raster_angle = tpp_config_msg.raster_angle;
-  tpp_config_msg.raster_wrt_global_axes = tpp_config_msg.raster_wrt_global_axes;
+  tpp_config_msg.raster_angle = tool_config.raster_angle;
+  tpp_config_msg.raster_wrt_global_axes = tool_config.raster_wrt_global_axes;
+  tpp_config_msg.generate_extra_rasters = tool_config.generate_extra_rasters;
 
   return std::move(tpp_config_msg);
 }

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -65,18 +65,16 @@ void flipPointOrder(tool_path_planner::ProcessPath& path)
   }
   path.line->GetPointData()->SetNormals(new_norms);
 
-  // flip derivative directions
+  // flip point order
   points = path.derivatives->GetPoints();
   vtkSmartPointer<vtkPoints> dpoints2 = vtkSmartPointer<vtkPoints>::New();
-
-  // flip point order
   for(int i = points->GetNumberOfPoints() - 1; i >= 0; --i)
   {
     dpoints2->InsertNextPoint(points->GetPoint(i));
   }
   path.derivatives->SetPoints(dpoints2);
 
-
+  // flip derivative directions
   vtkDataArray* ders = path.derivatives->GetPointData()->GetNormals();
   vtkSmartPointer<vtkDoubleArray> new_ders = vtkSmartPointer<vtkDoubleArray>::New();
   new_ders->SetNumberOfComponents(3);

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -185,8 +185,8 @@ tool_path_planner::ProcessTool fromTppMsg(const noether_msgs::ToolPathConfig& tp
     .min_hole_size = tpp_msg_config.min_hole_size,
     .min_segment_size = tpp_msg_config.min_segment_size,
     .raster_angle = tpp_msg_config.raster_angle,
-    .raster_wrt_global_axes = tpp_msg_config.raster_wrt_global_axes,
-    .generate_extra_rasters = tpp_msg_config.generate_extra_rasters
+    .raster_wrt_global_axes = static_cast<bool>(tpp_msg_config.raster_wrt_global_axes),
+    .generate_extra_rasters = static_cast<bool>(tpp_msg_config.generate_extra_rasters)
   };
 }
 

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -58,7 +58,7 @@ TEST(IntersectTest, RasterRotationTest)
     planner.setTool(tool);
     planner.setDebugMode(false);
     planner.setRasterAngle(direction);
-    planner.setRasterWRTPrincipalAxis(true);
+    planner.setRasterWRTGlobalAxis(false);
 
     vtk_viewer::VTKViewer viz;
     std::vector<float> color(3);
@@ -330,6 +330,154 @@ TEST(IntersectTest, TestCaseRansac)
   // Debug-specific code goes here
   viz.renderDisplay();
   #endif
+}
+
+TEST(IntersectTest, ExtraRasterTest)
+{
+  //
+  // Set up simple surface
+  //
+
+  // Planar Mesh
+  vtkSmartPointer<vtkPoints> points = vtk_viewer::createPlane(30, 10, vtk_viewer::FLAT);
+  vtkSmartPointer<vtkPolyData> data = vtk_viewer::createMesh(points, 0.5, 5);
+  vtk_viewer::generateNormals(data);
+
+  // create cutout in the middle of the mesh
+  vtkSmartPointer<vtkPoints> points2 = vtkSmartPointer<vtkPoints>::New();
+  double pt1[3] = { 2.0, 3.0, 0.0 };
+  double pt2[3] = { 4.0, 2.0, 0.0 };
+  double pt3[3] = { 5.0, 3.0, 0.0 };
+  double pt4[3] = { 4.0, 5.0, 0.0 };
+  points2->InsertNextPoint(pt1);
+  points2->InsertNextPoint(pt2);
+  points2->InsertNextPoint(pt3);
+  points2->InsertNextPoint(pt4);
+  vtkSmartPointer<vtkPolyData> data2 = vtkSmartPointer<vtkPolyData>::New();
+  data2 = vtk_viewer::cutMesh(data, points2, false);
+
+  // Set input mesh
+  tool_path_planner::RasterToolPathPlanner planner;
+  planner.setInputMesh(data2);
+
+  //
+  // Test on simple surface
+  //
+
+  // Set input tool data
+  tool_path_planner::ProcessTool tool;
+  tool.pt_spacing = POINT_SPACING;
+  tool.line_spacing = 0.75;
+  tool.tool_offset = 0.0;                // currently unused
+  tool.intersecting_plane_height = 0.2;  // 0.5 works best, not sure if this should be included in the tool
+  tool.min_hole_size = 0.1;
+  tool.raster_angle = 0.0;
+  tool.raster_wrt_global_axes = false;
+  tool.generate_extra_rasters = false;
+
+  planner.setDebugMode(false);
+
+  // Test on simple surface without extras
+  planner.setTool(tool);
+  ASSERT_TRUE(planner.computePaths());
+  std::vector<tool_path_planner::ProcessPath> paths_no_extras = planner.getPaths();
+
+  // Test on simple surface with extras
+  tool.generate_extra_rasters = true;
+  planner.setTool(tool);
+  ASSERT_TRUE(planner.computePaths());
+  std::vector<tool_path_planner::ProcessPath> paths_with_extras = planner.getPaths();
+
+  // Check that the number of rasters has increased by 2
+  ASSERT_EQ(paths_no_extras.size() + 2, paths_with_extras.size());
+
+#ifdef NDEBUG
+  // release build stuff goes here
+  LOG4CXX_INFO(tool_path_planner::RasterToolPathPlanner::RASTER_PATH_PLANNER_LOGGER, "noether/tool_path_planner test: visualization is only available in debug mode");
+
+#else
+  // Debug-specific code goes here
+  vtk_viewer::VTKViewer viz;
+  std::vector<float> color(3);
+  double scale = 1.0;
+
+  // Display mesh results
+  color[0] = 0.9f;
+  color[1] = 0.9f;
+  color[2] = 0.9f;
+  viz.addPolyDataDisplay(data2, color);
+
+  // Display surface normals
+  if(DISPLAY_NORMALS)
+  {
+    color[0] = 0.9;
+    color[1] = 0.1;
+    color[2] = 0.1;
+    vtkSmartPointer<vtkPolyData> normals_data = vtkSmartPointer<vtkPolyData>::New();
+    normals_data = planner.getInputMesh();
+    viz.addPolyNormalsDisplay(normals_data, color, scale);
+  }
+
+  // Display results without extra rasters
+  for(std::size_t i = 0; i < paths_no_extras.size(); ++i)
+  {
+    if(DISPLAY_LINES) // display line
+    {
+      color[0] = 0.2f;
+      color[1] = 0.9f;
+      color[2] = 0.2f;
+      viz.addPolyNormalsDisplay(paths_no_extras[i].line, color, scale);
+    }
+
+    if(DISPLAY_DERIVATIVES) // display derivatives
+    {
+    color[0] = 0.9f;
+    color[1] = 0.9f;
+    color[2] = 0.2f;
+    viz.addPolyNormalsDisplay(paths_no_extras[i].derivatives, color, scale);
+    }
+
+    if(DISPLAY_CUTTING_MESHES) // Display cutting mesh
+    {
+      color[0] = 0.9f;
+      color[1] = 0.9f;
+      color[2] = 0.9f;
+      viz.addPolyDataDisplay(paths_no_extras[i].intersection_plane, color);
+    }
+  }
+
+  viz.renderDisplay();
+
+  // Display results with extra rasters
+  for(std::size_t i = 0; i < paths_with_extras.size(); ++i)
+  {
+    if(DISPLAY_LINES) // display line
+    {
+      color[0] = 0.2f;
+      color[1] = 0.9f;
+      color[2] = 0.2f;
+      viz.addPolyNormalsDisplay(paths_with_extras[i].line, color, scale);
+    }
+
+    if(DISPLAY_DERIVATIVES) // display derivatives
+    {
+    color[0] = 0.9f;
+    color[1] = 0.9f;
+    color[2] = 0.2f;
+    viz.addPolyNormalsDisplay(paths_with_extras[i].derivatives, color, scale);
+    }
+
+    if(DISPLAY_CUTTING_MESHES) // Display cutting mesh
+    {
+      color[0] = 0.9f;
+      color[1] = 0.9f;
+      color[2] = 0.9f;
+      viz.addPolyDataDisplay(paths_with_extras[i].intersection_plane, color);
+    }
+  }
+
+  viz.renderDisplay();
+#endif
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This PR adds the ability to generate 'extra' strokes that lie entirely off the edge of the part.  This uses the existing offset-line generation to copy the last raster stroke generated.  This behavior is switched on and off using a new flag in the tool path config structure, which defaults to false.  This feature is limited by how 'good'/complete the last line appears.  If the last line from regular generation only stretches for half the part (as below), then the 'extra' line will only stretch for half the part.

![normal_angled](https://user-images.githubusercontent.com/18041827/57643282-f946b300-757e-11e9-84e4-17adec3d6960.png)
![extra_angled](https://user-images.githubusercontent.com/18041827/57643284-fb107680-757e-11e9-87d9-d458acd24185.png)