### PR TITLE
Correct License Information to Apache 2.0

### DIFF
--- a/mesh_segmenter/include/mesh_segmenter/mesh_segmenter.h
+++ b/mesh_segmenter/include/mesh_segmenter/mesh_segmenter.h
@@ -1,7 +1,20 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file mesh_segmenter.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef MESH_SEGMENTER_H

--- a/mesh_segmenter/package.xml
+++ b/mesh_segmenter/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The mesh_segmenter package</description>
   <maintainer email="alex.goins@swri.org">alex</maintainer>
-  <license>Proprietary</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/noether/include/noether/surface_raster_planner_application.h
+++ b/noether/include/noether/surface_raster_planner_application.h
@@ -1,7 +1,20 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file surface_raster_planner_application.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef INCLUDE_NOETHER_SURFACE_RASTER_PLANNER_APPLICATION_H

--- a/noether/package.xml
+++ b/noether/package.xml
@@ -5,7 +5,7 @@
   <description>The noether package</description>
   <author email="alex.goins@swri.org">alex</author>
   <maintainer email="jorge.nicho@swri.org">Jorge Nicho</maintainer>
-  <license>Proprietary</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>

--- a/noether_conversions/include/noether_conversions/noether_conversions.h
+++ b/noether_conversions/include/noether_conversions/noether_conversions.h
@@ -1,3 +1,22 @@
+/**
+ * @file noether_conversions.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <geometry_msgs/PoseArray.h>
 
 #include <tool_path_planner/tool_path_planner_base.h>

--- a/noether_conversions/package.xml
+++ b/noether_conversions/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The noether_conversions package</description>
   <maintainer email="Austin.Deric@swri.org">alex</maintainer>
-  <license>Proprietary</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>

--- a/noether_examples/include/noether_examples/noether_examples.h
+++ b/noether_examples/include/noether_examples/noether_examples.h
@@ -1,7 +1,20 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file noether_examples.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef INCLUDE_NOETHER_EXAMPLES_H

--- a/noether_examples/package.xml
+++ b/noether_examples/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The noether package</description>
   <maintainer email="alex.goins@swri.org">alex</maintainer>
-  <license>Proprietary</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>

--- a/noether_msgs/package.xml
+++ b/noether_msgs/package.xml
@@ -5,7 +5,8 @@
   <description>The noether_msgs package</description>
   <maintainer email="jorge.nicho@swri.org">Jorge Nicho</maintainer>  
   <author email="jorge.nicho@swri.org">Jorge Nicho</author>
-  <license>TODO</license>
+  <license>Apache 2.0</license>
+
   <buildtool_depend>catkin</buildtool_depend>
   <depend>actionlib</depend>
   <depend>actionlib_msgs</depend>

--- a/path_sequence_planner/include/path_sequence_planner/path_sequence_planner.h
+++ b/path_sequence_planner/include/path_sequence_planner/path_sequence_planner.h
@@ -1,7 +1,20 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file path_sequence_planner.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef PATH_SEQUENCE_PLANNER_H

--- a/path_sequence_planner/include/path_sequence_planner/simple_path_sequence_planner.h
+++ b/path_sequence_planner/include/path_sequence_planner/simple_path_sequence_planner.h
@@ -1,7 +1,20 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file simple_path_sequence_planner.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef SIMPLE_PATH_SEQUENCE_PLANNER_H

--- a/path_sequence_planner/package.xml
+++ b/path_sequence_planner/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The path_sequence_planner package</description>
   <maintainer email="alex.goins@swri.org">alex</maintainer>
-  <license>Proprietary</license>
+  <license>Apache 2.0</license>
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>vtk_viewer</build_depend>

--- a/tool_path_planner/include/tool_path_planner/raster_path_generator.h
+++ b/tool_path_planner/include/tool_path_planner/raster_path_generator.h
@@ -1,10 +1,23 @@
-/*
- * Copyright (c) 2018, Southwest Research Institute
- * All rights reserved.*
- * tool_path_generator.h
+/**
+ * @file raster_path_generator.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
- *  Created on: Nov 15, 2018
- *      Author: Jorge Nicho
+ * @author Jorge Nicho
+ * @date Nov 15, 2018
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef INCLUDE_TOOL_PATH_PLANNER_RASTER_PATH_GENERATOR_H_

--- a/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
+++ b/tool_path_planner/include/tool_path_planner/raster_tool_path_planner.h
@@ -3,6 +3,24 @@
  * All rights reserved.
  *
  */
+/**
+ * @file raster_tool_path_planner.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef RASTER_TOOL_PATH_PLANNER_H
 #define RASTER_TOOL_PATH_PLANNER_H

--- a/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
+++ b/tool_path_planner/include/tool_path_planner/tool_path_planner_base.h
@@ -1,7 +1,20 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file tool_path_planner_base.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef TOOL_PATH_PLANNER_H

--- a/tool_path_planner/include/tool_path_planner/utilities.h
+++ b/tool_path_planner/include/tool_path_planner/utilities.h
@@ -1,14 +1,24 @@
-/*
+/**
+ * @file mesh_segmenter.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
- * Copyright (c) 2018, Southwest Research Institute
- * All rights reserved.*
+ * @author Jorge Nicho
+ * @date Nov 15, 2018
  *
- * utilities.h
- *
- *  Created on: Nov 15, 2018
- *      Author: Jorge Nicho
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 
 #ifndef INCLUDE_TOOL_PATH_PLANNER_UTILITIES_H_
 #define INCLUDE_TOOL_PATH_PLANNER_UTILITIES_H_

--- a/tool_path_planner/package.xml
+++ b/tool_path_planner/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The path_planner package</description>
   <maintainer email="alex.goins@swri.org">alex</maintainer>
-  <license>Proprietary</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>

--- a/vtk_viewer/include/vtk_viewer/mouse_interactor.h
+++ b/vtk_viewer/include/vtk_viewer/mouse_interactor.h
@@ -1,3 +1,22 @@
+/**
+ * @file mouse_interactor.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef MOUSE_INTERACTOR_H
 #define MOUSE_INTERACTOR_H
 

--- a/vtk_viewer/include/vtk_viewer/vtk_utils.h
+++ b/vtk_viewer/include/vtk_viewer/vtk_utils.h
@@ -1,9 +1,21 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file vtk_utils.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 
 #ifndef NOETHER_VTK_UTILS_H
 #define NOETHER_VTK_UTILS_H

--- a/vtk_viewer/include/vtk_viewer/vtk_viewer.h
+++ b/vtk_viewer/include/vtk_viewer/vtk_viewer.h
@@ -1,7 +1,20 @@
-/*
- * Copyright (c) 2016, Southwest Research Institute
- * All rights reserved.
+/**
+ * @file vtk_viewer.h
+ * @copyright Copyright (c) 2019, Southwest Research Institute
  *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef VTK_VIEWER_H

--- a/vtk_viewer/package.xml
+++ b/vtk_viewer/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.0</version>
   <description>The vtk_viewer package</description>
   <maintainer email="alex.goins@swri.org">alex</maintainer>
-  <license>Proprietary</license>
+  <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cmake_modules</build_depend>


### PR DESCRIPTION
Noether was intended to be released as Apache 2.0 when it was released as open source. However, the license notices were never updated. This commit updates the notices in the headers as well as the package.xml to correctly state the license as Apache 2.0 rather than proprietary.

Addresses #44 and partially #14