### PR TITLE
sets the pcl verbosity level to L_ALWAYS to silence unnecessary error messages

### DIFF
--- a/noether/src/segmentation_server.cpp
+++ b/noether/src/segmentation_server.cpp
@@ -197,7 +197,8 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, "segmentation_server");
   ros::NodeHandle pnh("~");
-
+  vtkObject::GlobalWarningDisplayOff();
+  pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
   SegmentationAction segmenter(pnh, "segmenter");
   ros::spin();
 

--- a/tool_path_planner/src/raster_tool_path_planner.cpp
+++ b/tool_path_planner/src/raster_tool_path_planner.cpp
@@ -146,7 +146,10 @@ namespace tool_path_planner
       {
         LOG4CXX_WARN(RASTER_PATH_PLANNER_LOGGER, "Could not plan path for mesh " << i);
       }
-      paths.push_back(new_path);
+      else
+      {
+        paths.push_back(new_path);
+      }
     }
   }
 


### PR DESCRIPTION
Changes the PCL verbosity level in order to keep the console from being flooded with non fatal error messages