### PR TITLE
Noether Filtering PCL Flexibility

### DIFF
--- a/noether_filtering/CMakeLists.txt
+++ b/noether_filtering/CMakeLists.txt
@@ -1,9 +1,18 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(noether_filtering VERSION 0.0.0 LANGUAGES CXX)
 
+find_package(PCL 1.9 QUIET COMPONENTS common filters surface)
+if(${PCL_FOUND})
+  find_package(VTK 8.2 QUIET NO_MODULE)
+  if(${VTK_FOUND})
+    set(BUILD_MESH_PLUGINS TRUE)
+  endif()
+else()
+  find_package(PCL REQUIRED COMPONENTS common filters surface)
+  set(BUILD_MESH_PLUGINS FALSE)
+  message("PCL and/or VTK versions do not meet requirements for mesh plugins; compiling package without mesh plugins")
+endif()
 find_package(console_bridge REQUIRED)
-find_package(PCL 1.9 REQUIRED COMPONENTS common filters io surface)
-find_package(VTK 8.2 REQUIRED NO_MODULE)
 find_package(pluginlib REQUIRED)
 find_package(xmlrpcpp REQUIRED)
 
@@ -42,23 +51,41 @@ else()
   target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 endif()
 
-# Mesh Filters library
-add_library(${PROJECT_NAME}_mesh_filters SHARED
-  src/mesh/bspline_reconstruction.cpp
-)
-target_link_libraries(${PROJECT_NAME}_mesh_filters PUBLIC ${PROJECT_NAME})
-target_include_directories(${PROJECT_NAME}_mesh_filters PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>")
-set_target_properties(${PROJECT_NAME}_mesh_filters PROPERTIES
-  CXX_STANDARD 14
-  CXX_STANDARD_REQUIRED YES
-  CXX_EXTENSIONS NO
-)
-if(CXX_FEATURE_FOUND EQUAL "-1")
-  target_compile_options(${PROJECT_NAME}_mesh_filters PRIVATE -std=c++14)
-else()
-  target_compile_features(${PROJECT_NAME}_mesh_filters PRIVATE cxx_std_14)
+if(${BUILD_MESH_PLUGINS})
+  # Mesh Filters library
+  add_library(${PROJECT_NAME}_mesh_filters SHARED
+    src/mesh/bspline_reconstruction.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}_mesh_filters PUBLIC ${PROJECT_NAME})
+  target_include_directories(${PROJECT_NAME}_mesh_filters PUBLIC
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:include>")
+  set_target_properties(${PROJECT_NAME}_mesh_filters PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+  )
+  if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_mesh_filters PRIVATE -std=c++14)
+  else()
+    target_compile_features(${PROJECT_NAME}_mesh_filters PRIVATE cxx_std_14)
+  endif()
+
+  # Mesh Filter Plugins Library
+  add_library(${PROJECT_NAME}_mesh_filter_plugins SHARED src/mesh/plugins.cpp)
+  target_link_libraries(${PROJECT_NAME}_mesh_filter_plugins PUBLIC
+    ${PROJECT_NAME}_mesh_filters
+  )
+  set_target_properties(${PROJECT_NAME}_mesh_filter_plugins PROPERTIES
+    CXX_STANDARD 14
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+  )
+  if(CXX_FEATURE_FOUND EQUAL "-1")
+    target_compile_options(${PROJECT_NAME}_mesh_filter_plugins PRIVATE -std=c++14)
+  else()
+    target_compile_features(${PROJECT_NAME}_mesh_filter_plugins PRIVATE cxx_std_14)
+  endif()
 endif()
 
 # Cloud Filters library
@@ -77,27 +104,30 @@ else()
   target_compile_features(${PROJECT_NAME}_cloud_filters PRIVATE cxx_std_14)
 endif()
 
-# Filter Plugins Library
-add_library(${PROJECT_NAME}_filter_plugins SHARED src/plugins.cpp)
-target_link_libraries(${PROJECT_NAME}_filter_plugins PUBLIC
+# Cloud Filter Plugins Library
+add_library(${PROJECT_NAME}_cloud_filter_plugins SHARED src/cloud/plugins.cpp)
+target_link_libraries(${PROJECT_NAME}_cloud_filter_plugins PUBLIC
   ${PROJECT_NAME}_cloud_filters
-  ${PROJECT_NAME}_mesh_filters
 )
-set_target_properties(${PROJECT_NAME}_filter_plugins PROPERTIES
+set_target_properties(${PROJECT_NAME}_cloud_filter_plugins PROPERTIES
   CXX_STANDARD 14
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS NO
 )
 if(CXX_FEATURE_FOUND EQUAL "-1")
-  target_compile_options(${PROJECT_NAME}_filter_plugins PRIVATE -std=c++14)
+  target_compile_options(${PROJECT_NAME}_cloud_filter_plugins PRIVATE -std=c++14)
 else()
-  target_compile_features(${PROJECT_NAME}_filter_plugins PRIVATE cxx_std_14)
+  target_compile_features(${PROJECT_NAME}_cloud_filter_plugins PRIVATE cxx_std_14)
 endif()
 
 #############
 ## Install ##
 #############
-list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME} ${PROJECT_NAME}_mesh_filters ${PROJECT_NAME}_cloud_filters ${PROJECT_NAME}_filter_plugins)
+if(${BUILD_MESH_PLUGINS})
+  list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME} ${PROJECT_NAME}_mesh_filters ${PROJECT_NAME}_mesh_filter_plugins ${PROJECT_NAME}_cloud_filters ${PROJECT_NAME}_cloud_filter_plugins)
+else()
+  list(APPEND PACKAGE_LIBRARIES ${PROJECT_NAME} ${PROJECT_NAME}_cloud_filters ${PROJECT_NAME}_cloud_filter_plugins)
+endif()
 
 # Install targets
 install(TARGETS ${PACKAGE_LIBRARIES}
@@ -137,7 +167,7 @@ export(EXPORT ${PROJECT_NAME}-targets FILE
 ## Testing ##
 #############
 if(${ENABLE_TESTS})
-	
+
   # Download and unpack googletest at configure time
   configure_file(cmake/CMakeLists.txt.in googletest-download/CMakeLists.txt)
   execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
@@ -146,17 +176,17 @@ if(${ENABLE_TESTS})
   execute_process(COMMAND "${CMAKE_COMMAND}" --build .
       WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download"
   )
-  
+
   # Prevent GoogleTest from overriding our compiler/linker options
   # when building with Visual Studio
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-  
+
   # Add googletest directly to our build. This adds the following targets:
   # gtest, gtest_main, gmock and gmock_main
   add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
                    "${CMAKE_BINARY_DIR}/googletest-build"
   )
-  
+
   # The gtest/gmock targets carry header search path dependencies
   # automatically when using CMake 2.8.11 or later. Otherwise we
   # have to add them here ourselves.
@@ -164,16 +194,16 @@ if(${ENABLE_TESTS})
       include_directories("${gtest_SOURCE_DIR}/include"
                           "${gmock_SOURCE_DIR}/include"
       )
-  endif()	
-	
+  endif()
+
   add_executable(${PROJECT_NAME}_cloud_unit src/test/cloud_utest.cpp)
-  set_target_properties(${PROJECT_NAME}_filter_plugins PROPERTIES
+  set_target_properties(${PROJECT_NAME}_cloud_unit PROPERTIES
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
   )
   target_link_libraries(${PROJECT_NAME}_cloud_unit PUBLIC
-    ${PROJECT_NAME}_filter_plugins
+    ${PROJECT_NAME}_cloud_filter_plugins
     gtest_main
   )
   target_compile_options(${PROJECT_NAME}_cloud_unit PRIVATE -Wsuggest-override -Wconversion -Wsign-conversion)

--- a/noether_filtering/README.md
+++ b/noether_filtering/README.md
@@ -52,12 +52,17 @@ The following plugins are currently available and are listed by filter data type
 ### `pcl::PolygonMesh`
 - `noether_filtering::BSplineReconstruction`
 
+> Note: PCL 1.9 and VTK 8.2 are required to compile the mesh filtering plugins. If these system dependencies do not exist, the mesh filtering plugins will not be built
+
 ### `pcl::PointCloud`
 - `noether_filtering::CropBoxFilter<PointT>`
 - `noether_filtering::PassThrough<PointT>`
 - `noether_filtering::RadiusOutlierFilter<PointT>`
 - `noether_filtering::StatisticalOutlierFilter<PointT>`
 - `noether_filtering::VoxelGridFilter<PointT>`
+- `noether_filtering::MLSSmoothingFilter<PointT>`
 
-***Note:*** *a valid `PointT` type must be provided in the specification of the name of the plugin
-(i.e. `pcl::PointXYZ`)*
+> Note: a valid `PointT` type must be provided in the specification of the name of the plugin
+(i.e. `pcl::PointXYZ`)
+
+

--- a/noether_filtering/cloud_filter_plugins.xml
+++ b/noether_filtering/cloud_filter_plugins.xml
@@ -1,4 +1,4 @@
-<library path="lib/libnoether_filtering_filter_plugins">
+<library path="lib/libnoether_filtering_cloud_filter_plugins">
   <!-- pcl::PointXYZ -->
   <class name="noether_filtering::cloud::VoxelGridFilter&lt;pcl::PointXYZ>" type="noether_filtering::cloud::VoxelGridFilter&lt;pcl::PointXYZ>"
     base_class_type="noether_filtering::FilterBase&lt;pcl::PointCloud&lt;pcl::PointXYZ> >">

--- a/noether_filtering/mesh_filter_plugins.xml
+++ b/noether_filtering/mesh_filter_plugins.xml
@@ -1,5 +1,5 @@
-<library path="lib/libnoether_filtering_filter_plugins">
-  <class name="noether_filtering/BSplineReconstruction" type="noether_filtering::mesh::BSplineReconstruction" 
+<library path="lib/libnoether_filtering_mesh_filter_plugins">
+  <class name="noether_filtering/BSplineReconstruction" type="noether_filtering::mesh::BSplineReconstruction"
     base_class_type="noether_filtering::mesh::MeshFilterBase">
     <description>
       Fits a nurve surface to a polygonal mesh and clips the boundaries if requested

--- a/noether_filtering/src/cloud/plugins.cpp
+++ b/noether_filtering/src/cloud/plugins.cpp
@@ -10,9 +10,6 @@
 #include "noether_filtering/cloud/radius_outlier_filter.h"
 #include "noether_filtering/cloud/mls_smoothing_filter.h"
 
-// Mesh filters
-#include "noether_filtering/mesh/bspline_reconstruction.h"
-
 #define CREATE_FILTER_PLUGIN_IMPL(r, FILTER_TYPE, POINT_TYPE) \
   PLUGINLIB_EXPORT_CLASS(FILTER_TYPE<POINT_TYPE>, noether_filtering::FilterBase<pcl::PointCloud<POINT_TYPE>>)
 
@@ -26,6 +23,3 @@ CREATE_FILTER_PLUGINS(noether_filtering::cloud::CropBoxFilter, PCL_XYZ_POINT_TYP
 CREATE_FILTER_PLUGINS(noether_filtering::cloud::PassThroughFilter, PCL_XYZ_POINT_TYPES)
 CREATE_FILTER_PLUGINS(noether_filtering::cloud::RadiusOutlierFilter, PCL_XYZ_POINT_TYPES)
 CREATE_FILTER_PLUGINS(noether_filtering::cloud::MLSSmoothingFilter, PCL_XYZ_POINT_TYPES)
-
-// Mesh Filters
-PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::BSplineReconstruction, noether_filtering::mesh::MeshFilterBase)

--- a/noether_filtering/src/mesh/bspline_reconstruction.cpp
+++ b/noether_filtering/src/mesh/bspline_reconstruction.cpp
@@ -10,7 +10,6 @@
 #include <boost/make_shared.hpp>
 #include <console_bridge/console.h>
 #include <pcl/conversions.h>
-#include <pcl/io/vtk_lib_io.h>
 #include <pcl/surface/on_nurbs/triangulation.h>
 #include <XmlRpcException.h>
 

--- a/noether_filtering/src/mesh/plugins.cpp
+++ b/noether_filtering/src/mesh/plugins.cpp
@@ -1,0 +1,6 @@
+#include <pluginlib/class_list_macros.h>
+
+// Mesh filters
+#include "noether_filtering/mesh/bspline_reconstruction.h"
+
+PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::BSplineReconstruction, noether_filtering::mesh::MeshFilterBase)


### PR DESCRIPTION
PCL 1.9 and VTK 8.2 are currently only required for the mesh plugins. This PR checks if those versions of the package are available; if not, only the cloud filter plugins are built

Merge after #59 