### PR TITLE
Added PCL to the dependency list in the noether_conversions package

### DIFF
--- a/noether_conversions/CMakeLists.txt
+++ b/noether_conversions/CMakeLists.txt
@@ -25,6 +25,7 @@ catkin_package(
   DEPENDS
     EIGEN3
     VTK
+    PCL
 )
 
 include_directories(


### PR DESCRIPTION
PCL was missing and so building against the noether_conversions package would fail