### PR TITLE
Fix/remove need for vtk 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tool path planning and surface segmenter
 ---
 ## Installation
 
-This package depends on PCL 1.9.1 and VTK 8.2. 
+This package depends on PCL 1.9.1 and VTK 7.1.
 
 #### Prerequisites
 - **checkinstall**
@@ -18,7 +18,7 @@ This package depends on PCL 1.9.1 and VTK 8.2.
 
 #### Dependencies Installation
 ##### 1. VTK
-1. Download [VTK 8.2](https://github.com/Kitware/VTK/archive/v8.2.0.tar.gz)
+1. Download [VTK 7.1](https://github.com/Kitware/VTK/archive/v7.1.1.tar.gz)
 2. Unzip or extract into a user accessible directory
 3. `CD` into that directory and create a new `build` directory
 4. Run cmake
@@ -33,7 +33,7 @@ This package depends on PCL 1.9.1 and VTK 8.2.
     _This will take a while ..._
 2. Install 
     ```
-    sudo checkinstall --pkgname=vtk-8.2
+    sudo checkinstall --pkgname=vtk-7.1
     ```
     The installation process will prompt you to accept/reject some options prior to building the debian, **just follow the recommended prompts**.
     
@@ -43,7 +43,7 @@ This package depends on PCL 1.9.1 and VTK 8.2.
 1. Download [PCL 1.9.1](https://github.com/PointCloudLibrary/pcl/archive/pcl-1.9.1.tar.gz)
 2. Unzip or extract into a user accessible directory
 3. `cd` into that directory and locate the `CMakeLists.txt` file.
-4. Locate the `find package(VTK)` line (close to line 362) and edit it to `find_package(VTK 8.2 REQUIRED)`
+4. Locate the `find package(VTK)` line (close to line 362) and edit it to `find_package(VTK 7.1 REQUIRED)`
 5. Configure
     ```
     mkdir build

--- a/mesh_segmenter/CMakeLists.txt
+++ b/mesh_segmenter/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mesh_segmenter)
 ## Compile as C++14,
 add_compile_options(-std=c++14)
 
-find_package(VTK 8.2 REQUIRED NO_MODULE)
+find_package(VTK 7.1 REQUIRED NO_MODULE)
 include(${VTK_USE_FILE})
 
 find_package(catkin REQUIRED)

--- a/mesh_segmenter/include/mesh_segmenter/mesh_segmenter.h
+++ b/mesh_segmenter/include/mesh_segmenter/mesh_segmenter.h
@@ -66,7 +66,7 @@ public:
    * @brief empty constructor that sets default values of min_cluster_size_ = 50, max_cluster_size_ = 1000000, and
    * curvature_threshold_ = 0.3
    */
-  MeshSegmenter() : min_cluster_size_(50), max_cluster_size_(1000000), curvature_threshold_(0.3) { /*vtkObject::GlobalWarningDisplayOff();*/ }
+  MeshSegmenter() : min_cluster_size_(50), max_cluster_size_(1000000), curvature_threshold_(0.3) { vtkObject::GlobalWarningDisplayOff(); }
 
   /**
    * @brief setInputMesh Set the input mesh to be segmented

--- a/mesh_segmenter/include/mesh_segmenter/mesh_segmenter.h
+++ b/mesh_segmenter/include/mesh_segmenter/mesh_segmenter.h
@@ -66,7 +66,7 @@ public:
    * @brief empty constructor that sets default values of min_cluster_size_ = 50, max_cluster_size_ = 1000000, and
    * curvature_threshold_ = 0.3
    */
-  MeshSegmenter() : min_cluster_size_(50), max_cluster_size_(1000000), curvature_threshold_(0.3) {}
+  MeshSegmenter() : min_cluster_size_(50), max_cluster_size_(1000000), curvature_threshold_(0.3) { /*vtkObject::GlobalWarningDisplayOff();*/ }
 
   /**
    * @brief setInputMesh Set the input mesh to be segmented

--- a/noether/CMakeLists.txt
+++ b/noether/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options(-std=c++14)
 
 project(noether)
 
-find_package(VTK 8.2 REQUIRED NO_MODULE)
+find_package(VTK 7.1 REQUIRED NO_MODULE)
 include(${VTK_USE_FILE})
 
 find_package(catkin REQUIRED COMPONENTS

--- a/noether_conversions/CMakeLists.txt
+++ b/noether_conversions/CMakeLists.txt
@@ -1,16 +1,19 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(noether_conversions)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   eigen_conversions
   geometry_msgs
+  shape_msgs
 )
 
-find_package(VTK 8.2 REQUIRED NO_MODULE)
+find_package(VTK 7.1 REQUIRED NO_MODULE)
 include(${VTK_USE_FILE})
 
-find_package(PCL 1.8 REQUIRED)
+find_package(PCL 1.9 REQUIRED)
 
 find_package(Eigen3 REQUIRED)
 
@@ -22,6 +25,7 @@ catkin_package(
   CATKIN_DEPENDS
     eigen_conversions
     geometry_msgs
+    shape_msgs
   DEPENDS
     EIGEN3
     VTK

--- a/noether_conversions/package.xml
+++ b/noether_conversions/package.xml
@@ -11,4 +11,5 @@
 
   <depend>geometry_msgs</depend>
   <depend>eigen_conversions</depend>
+  <depend>shape_msgs</depend>
 </package>

--- a/noether_conversions/src/noether_conversions.cpp
+++ b/noether_conversions/src/noether_conversions.cpp
@@ -1,11 +1,14 @@
 #include <noether_conversions/noether_conversions.h>
+
 #include <Eigen/Geometry>
-#include <vtkPointData.h>
 #include <pcl/conversions.h>
-#include <pcl/point_types.h>
 #include <pcl/io/ply_io.h>
-#include <eigen_conversions/eigen_msg.h>
+#include <pcl/point_types.h>
+#include <vtkPointData.h>
+
 #include <console_bridge/console.h>
+#include <eigen_conversions/eigen_msg.h>
+#include <shape_msgs/MeshTriangle.h>
 
 namespace noether_conversions
 {
@@ -15,7 +18,7 @@ bool convertToPCLMesh(const shape_msgs::Mesh& mesh_msg, pcl::PolygonMesh& mesh)
   // iterating over triangles
   pcl::PointCloud<pcl::PointXYZ> mesh_points;
   mesh.polygons.clear();
-  for(auto& triangle : mesh_msg.triangles)
+  for (auto& triangle : mesh_msg.triangles)
   {
     pcl::Vertices vertices;
     vertices.vertices.assign(triangle.vertex_indices.begin(),triangle.vertex_indices.end());

--- a/noether_examples/CMakeLists.txt
+++ b/noether_examples/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options(-std=c++14)
 
 project(noether_examples)
 
-find_package(VTK 8.2 REQUIRED NO_MODULE)
+find_package(VTK 7.1 REQUIRED NO_MODULE)
 include(${VTK_USE_FILE})
 find_package(PCL 1.9 REQUIRED)
 

--- a/noether_filtering/CMakeLists.txt
+++ b/noether_filtering/CMakeLists.txt
@@ -3,7 +3,7 @@ project(noether_filtering VERSION 0.0.0 LANGUAGES CXX)
 
 find_package(PCL 1.9 QUIET COMPONENTS common filters surface)
 if(${PCL_FOUND})
-  find_package(VTK 8.2 QUIET NO_MODULE)
+  find_package(VTK 7.1 QUIET NO_MODULE)
   if(${VTK_FOUND})
     set(BUILD_MESH_PLUGINS TRUE)
   endif()

--- a/path_sequence_planner/CMakeLists.txt
+++ b/path_sequence_planner/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options(-std=c++14)
 
 project(path_sequence_planner)
 
-find_package(VTK 8.2 REQUIRED NO_MODULE)
+find_package(VTK 7.1 REQUIRED NO_MODULE)
 include(${VTK_USE_FILE})
 
 find_package(catkin REQUIRED COMPONENTS

--- a/tool_path_planner/CMakeLists.txt
+++ b/tool_path_planner/CMakeLists.txt
@@ -17,10 +17,10 @@ find_package(catkin REQUIRED COMPONENTS
   vtk_viewer
 )
 
-find_package(VTK 8.2 REQUIRED NO_MODULE)
+find_package(VTK 7.1 REQUIRED NO_MODULE)
 include(${VTK_USE_FILE})
 
-find_package(PCL 1.8 REQUIRED)
+find_package(PCL 1.9 REQUIRED)
 add_definitions(${PCL_DEFINITIONS})
 
 find_package(Eigen3 REQUIRED)

--- a/vtk_viewer/CMakeLists.txt
+++ b/vtk_viewer/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   rosconsole
 )
 
-find_package(VTK 8.2 REQUIRED NO_MODULE)
+find_package(VTK 7.1 REQUIRED NO_MODULE)
 include(${VTK_USE_FILE})
 
 find_package(PCL 1.9 REQUIRED)


### PR DESCRIPTION
VTK 7.1 is actually available as a debian package starting in Ubuntu 18.04.  Staying on VTK 7.1 would therefore allow some people to use this library without building VTK from source.

I do not believe any new capability from VTK 8.2 is in use, so moving back to VTK 7.1 should not cause any problems.

If I am not mistaken, the motive for moving to VTK 8.2 was to suppress deprecation warnings printed during segmentation.  There is a function in vtkObject that allows the suppression of terminal output.  Calling this function during the construction of a segmentation object would prevent these messages from printing.  (This change has been made.)  It would also be possible to find the exact line that references deprecated code, and wrap it in calls to turn the output off then on.  This way, any other VTK output can remain visible.  (This change has not been made.)

Also, the package did not build with --install set in catkin, as the noether_conversions package relied on C++11 functionality, but did not specify C++11.  This has been fixed.