### PR TITLE
Feature halfedge boundary finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ The mesh filtering demo applies a bspline smoothing algorithm to a noisy mesh, r
 roslaunch noether_examples mesh_filtering_demo.launch
 ```
 
-Currently the only plugin available is the `noether_filtering/BSplineReconstruction`, however custom mesh filter plugins can be added by inheriting from the `noether_filtering::mesh::MeshBaseFilter` class.
+- Filter your own *ply* mesh file
+```
+roslaunch noether_examples mesh_filtering_demo.launch mesh_file:=/path/to/my/mesh.ply
+```
+
+Currently the only plugins available are `noether_filtering/BSplineReconstruction` and `noether_filtering/EuclideanClustering`,  
+ however custom mesh filter plugins can be added by inheriting from the `noether_filtering::mesh::MeshBaseFilter` class.
+
+### Generate Edge Paths Demo
+Runs an algorithm that identifies all the half edges that constiture the boundary
+- On a dummy *ply* mesh file
+```
+roslaunch noether_examples halfedge_finder_demo.launch
+```
+
+- On your own *ply* mesh file
+```
+roslaunch noether_examples halfedge_finder_demo.launch mesh_file:=/path/to/my/mesh.ply
+```
 
 

--- a/noether/CMakeLists.txt
+++ b/noether/CMakeLists.txt
@@ -106,7 +106,9 @@ target_link_libraries(halfedge_boundary_finder_server
 #############
 ## Install ##
 #############
-install(TARGETS segmentation_server surface_raster_planner_application surface_raster_planner_server mesh_filter_server edge_generator_server
+install(TARGETS segmentation_server surface_raster_planner_application 
+  surface_raster_planner_server mesh_filter_server edge_generator_server
+  halfedge_boundary_finder_server
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/noether/CMakeLists.txt
+++ b/noether/CMakeLists.txt
@@ -96,6 +96,13 @@ target_link_libraries(edge_generator_server
   ${catkin_LIBRARIES}
 )
 
+add_executable(halfedge_boundary_finder_server
+  src/halfedge_boundary_finder_server.cpp
+)
+target_link_libraries(halfedge_boundary_finder_server 
+  ${catkin_LIBRARIES}
+)
+
 #############
 ## Install ##
 #############

--- a/noether/config/halfedge_boundary_finder.yaml
+++ b/noether/config/halfedge_boundary_finder.yaml
@@ -1,2 +1,5 @@
 min_num_points: 50
 min_point_dist: 0.02
+normal_averaging: True
+normal_search_radius: 0.1
+normal_influence_weight: 1.0

--- a/noether/config/halfedge_boundary_finder.yaml
+++ b/noether/config/halfedge_boundary_finder.yaml
@@ -1,0 +1,2 @@
+min_num_points: 50
+min_point_dist: 0.02

--- a/noether/launch/halfedge_boundary_finder_server.launch
+++ b/noether/launch/halfedge_boundary_finder_server.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="halfedge_boundary_finder_server" type="halfedge_boundary_finder_server" pkg="noether" output="screen">
+    <rosparam command="load" ns="halfedge_boundary_config" file="$(find noether)/config/halfedge_boundary_finder.yaml"/>
+  </node>
+
+</launch>

--- a/noether/src/halfedge_boundary_finder_server.cpp
+++ b/noether/src/halfedge_boundary_finder_server.cpp
@@ -1,0 +1,169 @@
+/**
+ * @author Jorge Nicho <jrgnichodevel@gmail.com>
+ * @file halfedge_boundary_finder_server.cpp
+ * @date Dec 5, 2019
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <ros/ros.h>
+#include <boost/format.hpp>
+#include <console_bridge/console.h>
+#include <XmlRpcException.h>
+#include <actionlib/server/simple_action_server.h>
+#include <noether_msgs/GenerateEdgePathsAction.h>
+#include <noether_conversions/noether_conversions.h>
+#include <tool_path_planner/half_edge_boundary_finder.h>
+
+static const double FEEDBACK_PUBLISH_PERIOD = 1.0; // seconds
+static const std::string GENERATE_EDGE_PATHS_ACTION = "generate_edge_paths";
+static const std::string HALFEDGE_BOUNDARY_CONFIG_PARAM = "halfedge_boundary_config";
+
+class BoundaryFinderServer
+{
+public:
+  BoundaryFinderServer():
+    server_(nh_, GENERATE_EDGE_PATHS_ACTION, boost::bind(&BoundaryFinderServer::executeAction, this, _1),false)
+  {
+
+  }
+
+  ~BoundaryFinderServer()
+  {
+
+  }
+
+  bool run()
+  {
+    if(!loadConfig())
+    {
+      return false;
+    }
+    server_.start();
+    ROS_INFO("Boundary Finder Server is ready ...");
+    return true;
+  }
+
+protected:
+
+  bool loadConfig()
+  {
+    using namespace XmlRpc;
+
+    ros::NodeHandle ph("~");
+    XmlRpcValue config;
+    if(!ph.getParam(HALFEDGE_BOUNDARY_CONFIG_PARAM,config))
+    {
+      ROS_ERROR("Did not find the '%s' parameter", HALFEDGE_BOUNDARY_CONFIG_PARAM.c_str());
+      return false;
+    }
+
+    try
+    {
+      config_.min_num_points = static_cast<int>(config["min_num_points"]);
+      config_.min_point_dist = static_cast<double>(config["min_point_dist"]);
+    }
+    catch(XmlRpcException& e)
+    {
+      ROS_ERROR("Fail to parse edge generation config file, error msg: %s", e.getMessage().c_str());
+      return false;
+    }
+    return true;
+  }
+
+  void executeAction(const noether_msgs::GenerateEdgePathsGoalConstPtr& goal)
+  {
+    using namespace noether_msgs;
+    noether_msgs::GenerateEdgePathsFeedback feedback;
+    noether_msgs::GenerateEdgePathsResult res;
+
+    if(!loadConfig())
+    {
+      ROS_WARN("Could not load configuration, using previous one");
+    }
+
+    ros::Timer feedback_timer = nh_.createTimer(ros::Duration(),[&](const ros::TimerEvent& evnt)
+    {
+      server_.publishFeedback(feedback);
+    });
+
+    for(std::size_t i = 0; i < goal->surface_meshes.size(); i++)
+    {
+      auto& mesh = goal->surface_meshes[i];
+      feedback.current_mesh_index = i;
+      edge_path_gen_.setInput(mesh);
+      boost::optional< std::vector<geometry_msgs::PoseArray> > edge_path_poses = edge_path_gen_.generate(config_);
+      if(!edge_path_poses)
+      {
+        res.validities.push_back(false);
+        res.edge_paths.push_back(ToolRasterPath());
+
+        if(!goal->proceed_on_failure)
+        {
+          res.success = false;
+          break;
+        }
+      }
+      else
+      {
+        ToolRasterPath edge_path;
+        edge_path.paths = edge_path_poses.get();
+        res.edge_paths.push_back(std::move(edge_path));
+        res.validities.push_back(true);
+      }
+    }
+
+    if(goal->proceed_on_failure)
+    {
+      res.success = std::any_of(res.validities.begin(), res.validities.end(),[](const bool& b){
+        return b;
+      });
+    }
+
+    if(res.success)
+    {
+      server_.setSucceeded(res);
+    }
+    else
+    {
+      server_.setAborted(res);
+    }
+  }
+
+  ros::NodeHandle nh_;
+  actionlib::SimpleActionServer<noether_msgs::GenerateEdgePathsAction> server_;
+  tool_path_planner::HalfEdgeBoundaryFinder::Config config_;
+  tool_path_planner::HalfEdgeBoundaryFinder edge_path_gen_;
+
+};
+
+int main(int argc,char** argv)
+{
+  ros::init(argc,argv,"edge_generator_server");
+  ros::AsyncSpinner spinner(2);
+  spinner.start();
+  console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO);
+  BoundaryFinderServer server;
+  if(!server.run())
+  {
+    return -1;
+  }
+
+  ros::waitForShutdown();
+  return 0;
+}
+

--- a/noether/src/halfedge_boundary_finder_server.cpp
+++ b/noether/src/halfedge_boundary_finder_server.cpp
@@ -76,6 +76,9 @@ protected:
     {
       config_.min_num_points = static_cast<int>(config["min_num_points"]);
       config_.min_point_dist = static_cast<double>(config["min_point_dist"]);
+      config_.normal_averaging = static_cast<bool>(config["normal_averaging"]);
+      config_.normal_search_radius = static_cast<double>(config["normal_search_radius"]);
+      config_.normal_influence_weight = static_cast<double>(config["normal_influence_weight"]);
     }
     catch(XmlRpcException& e)
     {

--- a/noether_examples/CMakeLists.txt
+++ b/noether_examples/CMakeLists.txt
@@ -91,6 +91,13 @@ target_link_libraries(edge_generator_client
   ${catkin_LIBRARIES}
 )
 
+add_executable(halfedge_finder_node
+  src/halfedge_finder_node.cpp
+)
+target_link_libraries(halfedge_finder_node
+  ${catkin_LIBRARIES}
+)
+
 #############
 ## Install ##
 #############

--- a/noether_examples/CMakeLists.txt
+++ b/noether_examples/CMakeLists.txt
@@ -101,7 +101,7 @@ target_link_libraries(halfedge_finder_node
 #############
 ## Install ##
 #############
-install(TARGETS mesh_segmenter_client_node mesh_segmenter_node edge_generator_client
+install(TARGETS mesh_segmenter_client_node mesh_segmenter_node edge_generator_client halfedge_finder_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/noether_examples/config/halfedge_finder.rviz
+++ b/noether_examples/config/halfedge_finder.rviz
@@ -1,0 +1,135 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /MarkerArray1
+        - /MarkerArray1/Namespaces1
+        - /MarkerArray2
+      Splitter Ratio: 0.5124716758728027
+    Tree Height: 751
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /boundary_lines
+      Name: MarkerArray
+      Namespaces:
+        edge_0: true
+        input_mesh: false
+      Queue Size: 100
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /boundary_poses
+      Name: MarkerArray
+      Namespaces:
+        edge_0: true
+      Queue Size: 100
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 136; 138; 133
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 2.1891911029815674
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.513699471950531
+        Y: 0.7756494283676147
+        Z: 0.5893992185592651
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.5703974962234497
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.6254138946533203
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1026
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001bb0000037afc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000270000037a000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000037afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007301000000270000037a000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006900000003efc0100000002fb0000000800540069006d0065010000000000000690000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000003ba0000037a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1680
+  X: 0
+  Y: 24

--- a/noether_examples/config/halfedge_finder.rviz
+++ b/noether_examples/config/halfedge_finder.rviz
@@ -59,7 +59,7 @@ Visualization Manager:
       Name: MarkerArray
       Namespaces:
         edge_0: true
-        input_mesh: false
+        input_mesh: true
       Queue Size: 100
       Value: true
     - Class: rviz/MarkerArray
@@ -95,25 +95,25 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 2.1891911029815674
+      Distance: 1.360137701034546
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -0.513699471950531
-        Y: 0.7756494283676147
-        Z: 0.5893992185592651
+        X: -0.5391342043876648
+        Y: 1.515692949295044
+        Z: 0.03754088655114174
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.5703974962234497
+      Pitch: 0.8153972625732422
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 0.6254138946533203
+      Yaw: 5.178586483001709
     Saved: ~
 Window Geometry:
   Displays:

--- a/noether_examples/launch/halfedge_finder.launch
+++ b/noether_examples/launch/halfedge_finder.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="min_num_points" default="10"/>
+  <arg name="min_point_dist" default="0.02"/>
+  <arg name="mesh_file" default="$(find noether_examples)/data/raw_mesh.ply"/>
+  <node name="halfedge_finder_node" pkg="noether_examples" type="halfedge_finder_node" output="screen">
+    <param name="mesh_file" value="$(arg mesh_file)"/>
+    <param name="min_num_points" value="$(arg min_num_points)"/>
+    <param name="min_point_dist" value="$(arg min_point_dist)"/>
+  </node>
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find noether_examples)/config/halfedge_finder.rviz"/>  
+</launch>

--- a/noether_examples/launch/halfedge_finder_demo.launch
+++ b/noether_examples/launch/halfedge_finder_demo.launch
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="min_num_points" default="10"/>
-  <arg name="min_point_dist" default="0.02"/>
   <arg name="mesh_file" default="$(find noether_examples)/data/raw_mesh.ply"/>
   <node name="halfedge_finder_node" pkg="noether_examples" type="halfedge_finder_node" output="screen">
     <param name="mesh_file" value="$(arg mesh_file)"/>
-    <param name="min_num_points" value="$(arg min_num_points)"/>
-    <param name="min_point_dist" value="$(arg min_point_dist)"/>
   </node>
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find noether_examples)/config/halfedge_finder.rviz"/>  
+  <include file="$(find noether)/launch/halfedge_boundary_finder_server.launch"/>
 </launch>

--- a/noether_examples/src/halfedge_finder_node.cpp
+++ b/noether_examples/src/halfedge_finder_node.cpp
@@ -38,6 +38,7 @@ static const std::string BOUNDARY_POSES_MARKERS_TOPIC ="boundary_poses";
 static const std::string EDGE_PATH_NS = "edge_";
 static const std::string INPUT_MESH_NS = "input_mesh";
 static const RGBA RAW_MESH_RGBA = std::make_tuple(0.6, 0.6, 1.0, 1.0);
+static const std::size_t MAX_MARKERS_ON_DISPLAY = 500;
 
 std::size_t countPathPoints(const noether_msgs::ToolRasterPath& rasters)
 {
@@ -135,7 +136,6 @@ public:
     {
       ROS_INFO("Edge %lu contains %lu points",i, countPathPoints(boundary_poses[i]));
 
-
       std::string ns = EDGE_PATH_NS + std::to_string(i);
       visualization_msgs::MarkerArray edge_path_axis_markers = convertToAxisMarkers(boundary_poses[i],
                                                                                DEFAULT_FRAME_ID,
@@ -145,13 +145,15 @@ public:
                                                                                DEFAULT_FRAME_ID,
                                                                                ns);
 
-      if(poses_markers_.markers.size() > 500)
+      if(poses_markers_.markers.size() > MAX_MARKERS_ON_DISPLAY)
       {
+        // prevents buffer overruns
         poses_markers_.markers.clear();
       }
 
-      if(line_markers_.markers.size() > 500)
+      if(line_markers_.markers.size() > MAX_MARKERS_ON_DISPLAY) // prevents buffer overruns
       {
+        // prevents buffer overruns
         line_markers_.markers.clear();
       }
 

--- a/noether_examples/src/halfedge_finder_node.cpp
+++ b/noether_examples/src/halfedge_finder_node.cpp
@@ -1,0 +1,156 @@
+/*
+ * halfedge_finder_node.cpp
+ *
+ *  Created on: Dec 5, 2019
+ *      Author: jrgnicho
+ */
+
+#include <ros/ros.h>
+#include <boost/format.hpp>
+#include <boost/filesystem.hpp>
+#include <noether_conversions/noether_conversions.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <tool_path_planner/half_edge_boundary_finder.h>
+#include <console_bridge/console.h>
+
+using RGBA = std::tuple<double,double,double,double>;
+
+static const std::string DEFAULT_FRAME_ID = "world";
+static const std::string BOUNDARY_LINES_MARKERS_TOPIC ="boundary_lines";
+static const std::string BOUNDARY_POSES_MARKERS_TOPIC ="boundary_poses";
+static const std::string EDGE_PATH_NS = "edge_";
+static const std::string EDGE_PATH_LINE_NS = "edge_path_lines";
+static const std::string INPUT_MESH_NS = "input_mesh";
+static const RGBA RAW_MESH_RGBA = std::make_tuple(0.6, 0.6, 1.0, 1.0);
+
+class HalfEdgeFinder
+{
+public:
+
+  HalfEdgeFinder(ros::NodeHandle nh):
+    nh_(nh)
+  {
+    boundary_lines_markers_pub_ = nh_.advertise<visualization_msgs::MarkerArray>(BOUNDARY_LINES_MARKERS_TOPIC,1);
+    boundary_poses_markers_pub_ = nh_.advertise<visualization_msgs::MarkerArray>(BOUNDARY_POSES_MARKERS_TOPIC,1);
+  }
+
+  ~HalfEdgeFinder()
+  {
+
+  }
+
+  bool run()
+  {
+    using namespace noether_conversions;
+
+    // loading parameters
+    ros::NodeHandle ph("~");
+    std::string mesh_file;
+    int min_num_points = 50;
+    double min_point_dist = 0.02;
+    if(!ph.getParam("mesh_file",mesh_file))
+    {
+      ROS_ERROR("Failed to load one or more parameters");
+      return false;
+    }
+
+    bool loaded_params = ph.param<int>("min_num_points",min_num_points,min_num_points) &&
+        ph.param<double>("min_point_dist",min_point_dist,min_point_dist);
+    if(!loaded_params)
+    {
+      ROS_WARN("One or more non-critical parameters were not loaded, using defaults");
+    }
+
+    markers_publish_timer_ = nh_.createTimer(ros::Duration(0.5),[&](const ros::TimerEvent& e){
+      if(!line_markers_.markers.empty())
+      {
+        boundary_lines_markers_pub_.publish(line_markers_);
+      }
+
+      if(!poses_markers_.markers.empty())
+      {
+        boundary_poses_markers_pub_.publish(poses_markers_);
+      }
+    });
+
+    shape_msgs::Mesh mesh_msg;
+    if(!noether_conversions::loadPLYFile(mesh_file,mesh_msg))
+    {
+      ROS_ERROR("Failed to read file %s",mesh_file.c_str());
+      return false;
+    }
+    line_markers_.markers.push_back(createMeshMarker(mesh_file,INPUT_MESH_NS,DEFAULT_FRAME_ID,RAW_MESH_RGBA));
+
+    tool_path_planner::HalfEdgeBoundaryFinder edge_finder;
+    decltype(edge_finder)::Config config = {.min_num_points = min_num_points,
+                                            .min_point_dist = min_point_dist};
+    edge_finder.setInput(mesh_msg);
+    ROS_INFO("Computing edges");
+    boost::optional<std::vector<geometry_msgs::PoseArray>> res = edge_finder.generate(config);
+    const std::vector<geometry_msgs::PoseArray>& boundary_poses = res.get();
+
+    ROS_INFO("Found %lu edges",boundary_poses.size());
+
+    for(std::size_t i = 0; i < boundary_poses.size(); i++)
+    {
+      ROS_INFO("Edge %lu contains %lu points",i, boundary_poses[i].poses.size());
+
+      std::string ns = EDGE_PATH_NS + std::to_string(i);
+      visualization_msgs::MarkerArray edge_path_axis_markers = convertToAxisMarkers({boundary_poses[i]},
+                                                                               DEFAULT_FRAME_ID,
+                                                                               ns);
+
+      visualization_msgs::MarkerArray edge_path_line_markers = convertToDottedLineMarker({boundary_poses[i]},
+                                                                               DEFAULT_FRAME_ID,
+                                                                               ns);
+
+      if(poses_markers_.markers.size() > 500)
+      {
+        poses_markers_.markers.clear();
+      }
+
+      if(line_markers_.markers.size() > 500)
+      {
+        line_markers_.markers.clear();
+      }
+
+      poses_markers_.markers.insert( poses_markers_.markers.end(),
+                               edge_path_axis_markers.markers.begin(), edge_path_axis_markers.markers.end());
+      line_markers_.markers.insert( line_markers_.markers.end(),
+                               edge_path_line_markers.markers.begin(), edge_path_line_markers.markers.end());
+    }
+    return true;
+  }
+
+private:
+  ros::NodeHandle nh_;
+  ros::Timer markers_publish_timer_;
+  ros::Publisher boundary_lines_markers_pub_;
+  ros::Publisher boundary_poses_markers_pub_;
+  visualization_msgs::MarkerArray line_markers_;
+  visualization_msgs::MarkerArray poses_markers_;
+
+
+
+};
+
+int main(int argc, char** argv)
+{
+  ros::init(argc,argv,"halfedge_finder");
+  ros::NodeHandle nh;
+  ros::AsyncSpinner spinner(2);
+  spinner.start();
+  console_bridge::setLogLevel(console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_INFO);
+  HalfEdgeFinder edge_finder(nh);
+  if(!edge_finder.run())
+  {
+    return -1;
+  }
+  ros::waitForShutdown();
+  return 0;
+}
+
+
+
+
+

--- a/tool_path_planner/CMakeLists.txt
+++ b/tool_path_planner/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(${PROJECT_NAME}
   src/raster_path_generator.cpp
   src/raster_tool_path_planner.cpp
   src/edge_path_generator.cpp
+  src/halfedge_boundary_finder.cpp
   src/utilities.cpp
 )
 target_link_libraries(${PROJECT_NAME}

--- a/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
+++ b/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
@@ -1,0 +1,73 @@
+/**
+ * @author Jorge Nicho
+ * @file mesh_boundary_finder.h
+ * @date Dec 5, 2019
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDE_TOOL_PATH_PLANNER_HALF_EDGE_BOUNDARY_FINDER_H_
+#define INCLUDE_TOOL_PATH_PLANNER_HALF_EDGE_BOUNDARY_FINDER_H_
+
+#include <boost/optional.hpp>
+#include <pcl/PolygonMesh.h>
+#include <shape_msgs/Mesh.h>
+#include <geometry_msgs/PoseArray.h>
+
+namespace tool_path_planner
+{
+
+
+class HalfEdgeBoundaryFinder
+{
+public:
+
+  struct Config
+  {
+    std::size_t min_num_points = 200;
+    double min_point_dist = 0.01;
+  };
+
+  HalfEdgeBoundaryFinder();
+  virtual ~HalfEdgeBoundaryFinder();
+
+
+  /**
+   * @brief sets the input mesh from which edges are to be generated
+   * @param mesh The mesh input
+   */
+  void setInput(pcl::PolygonMesh::ConstPtr mesh);
+
+  /**
+   * @brief sets the input mesh from which edges are to be generated
+   * @param mesh The mesh input
+   */
+  void setInput(const shape_msgs::Mesh& mesh);
+
+  /**
+   * @brief Generate the edge poses that follow the contour of the mesh
+   * @param config The configuration
+   * @return  An array of edge poses or boost::none when it fails.
+   */
+  boost::optional< std::vector<geometry_msgs::PoseArray> > generate(const HalfEdgeBoundaryFinder::Config& config);
+
+protected:
+  pcl::PolygonMesh::ConstPtr mesh_;
+};
+
+} /* namespace tool_path_planner */
+
+#endif /* INCLUDE_TOOL_PATH_PLANNER_HALF_EDGE_BOUNDARY_FINDER_H_ */

--- a/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
+++ b/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
@@ -41,8 +41,12 @@ public:
 
   struct Config
   {
-    std::size_t min_num_points = 200;   /**@brief only edge segments with more than this many points will be returned*/
-    double min_point_dist = 0.01;       /**@brief minimum distance for adjacent points, set to < 0 to turn off this constraint */
+    std::size_t min_num_points = 200;     /**@brief only edge segments with more than this many points will be returned*/
+    double min_point_dist = 0.01;         /**@brief minimum distance for adjacent points, set to < 0 to turn off this constraint */
+    bool normal_averaging = true;         /**@brief True in order set the normal of each point as the average of the normal vectors
+                                                  of the points within a specified radius*/
+    double normal_search_radius = 0.02;   /**@brief The search radius used for normal averaging */
+    double normal_influence_weight = 0.5; /**@brief A value [0, 1] that influences the normal averaged based on its distance, set to 0 to disable */
   };
 
   HalfEdgeBoundaryFinder();

--- a/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
+++ b/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
@@ -31,14 +31,18 @@ namespace tool_path_planner
 {
 
 
+/**
+ * @class tool_path_planner::HalfEdgeBoundaryFinder
+ * @details Computes the edges of a mesh by extracting the mesh half edges, needs a mesh that does not have duplicate points
+ */
 class HalfEdgeBoundaryFinder
 {
 public:
 
   struct Config
   {
-    std::size_t min_num_points = 200;
-    double min_point_dist = 0.01;
+    std::size_t min_num_points = 200;   /**@brief only edge segments with more than this many points will be returned*/
+    double min_point_dist = 0.01;       /**@brief minimum distance for adjacent points, set to < 0 to turn off this constraint */
   };
 
   HalfEdgeBoundaryFinder();

--- a/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
+++ b/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
@@ -72,6 +72,24 @@ public:
    */
   boost::optional< std::vector<geometry_msgs::PoseArray> > generate(const HalfEdgeBoundaryFinder::Config& config);
 
+  /**
+   * @brief Generate the edge poses that follow the contour of the mesh
+   * @param mesh  The input mesh from which edges will be generated
+   * @param config The configuration
+   * @return  An array of edge poses or boost::none when it fails.
+   */
+  boost::optional< std::vector<geometry_msgs::PoseArray> > generate(const shape_msgs::Mesh& mesh,
+                                                                    const HalfEdgeBoundaryFinder::Config& config);
+
+  /**
+   * @brief Generate the edge poses that follow the contour of the mesh
+   * @param mesh  The input mesh from which edges will be generated
+   * @param config The configuration
+   * @return  An array of edge poses or boost::none when it fails.
+   */
+  boost::optional< std::vector<geometry_msgs::PoseArray> > generate(pcl::PolygonMesh::ConstPtr mesh,
+                                                                    const HalfEdgeBoundaryFinder::Config& config);
+
 protected:
   pcl::PolygonMesh::ConstPtr mesh_;
 };

--- a/tool_path_planner/include/tool_path_planner/utilities.h
+++ b/tool_path_planner/include/tool_path_planner/utilities.h
@@ -27,7 +27,8 @@
 #include <Eigen/Dense>
 #include <eigen_stl_containers/eigen_stl_containers.h>
 #include <geometry_msgs/PoseArray.h>
-
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
 #include "tool_path_planner_base.h"
 
 
@@ -75,6 +76,9 @@ namespace tool_path_planner
 	 * @return The rotation matrix
 	 */
 	Eigen::Matrix3d toRotationMatrix(const Eigen::Vector3d& vx, const Eigen::Vector3d& vy, const Eigen::Vector3d& vz);
+
+	bool createPoseArray(const pcl::PointCloud<pcl::PointNormal>& cloud_normals, const std::vector<int>& indices,
+	                     geometry_msgs::PoseArray& poses);
 
 }
 

--- a/tool_path_planner/include/tool_path_planner/utilities.h
+++ b/tool_path_planner/include/tool_path_planner/utilities.h
@@ -77,6 +77,16 @@ namespace tool_path_planner
 	 */
 	Eigen::Matrix3d toRotationMatrix(const Eigen::Vector3d& vx, const Eigen::Vector3d& vy, const Eigen::Vector3d& vz);
 
+	/**
+	 * @details Creates an array of poses from the point cloud with normals
+	 * It treats the point cloud as a set of consecutive points and so the x direction is along the line that
+	 * connects the current point to the next in the sequence .  The y vector is obtained from the cross product
+	 *  of the point normal and the x direction.
+	 * @param cloud_normals The points with normals
+	 * @param indices       Selects only these points, if left empty all points are used.
+	 * @poses               The output pose array
+	 * @return  True on success, false otherwise.
+	 */
 	bool createPoseArray(const pcl::PointCloud<pcl::PointNormal>& cloud_normals, const std::vector<int>& indices,
 	                     geometry_msgs::PoseArray& poses);
 

--- a/tool_path_planner/src/halfedge_boundary_finder.cpp
+++ b/tool_path_planner/src/halfedge_boundary_finder.cpp
@@ -1,0 +1,263 @@
+/**
+ * @author Jorge Nicho
+ * @file mesh_boundary_finder.cpp
+ * @date Dec 5, 2019
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <boost/bimap.hpp>
+#include <boost/make_shared.hpp>
+#include <pcl/geometry/triangle_mesh.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/PointIndices.h>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <console_bridge/console.h>
+#include <noether_conversions/noether_conversions.h>
+#include <tool_path_planner/half_edge_boundary_finder.h>
+#include <tool_path_planner/utilities.h>
+
+
+using MeshTraits = pcl::geometry::DefaultMeshTraits<std::size_t>;
+typedef pcl::geometry::TriangleMesh< MeshTraits > TraingleMesh;
+
+boost::optional<TraingleMesh> createTriangleMesh(const pcl::PolygonMesh& input_mesh)
+{
+  std::stringstream ss;
+  TraingleMesh mesh;
+  typedef boost::bimap<uint32_t, TraingleMesh::VertexIndex> MeshIndexMap;
+  MeshIndexMap mesh_index_map;
+  for (size_t ii = 0; ii < input_mesh.polygons.size(); ++ii)
+  {
+    const std::vector<uint32_t>& vertices = input_mesh.polygons.at(ii).vertices;
+    if (vertices.size() != 3)
+    {
+      ss.str("");
+      ss << "Found polygon with " << vertices.size() << " sides, only triangle mesh supported!";
+      CONSOLE_BRIDGE_logInform(ss.str().c_str());
+      return boost::none;
+    }
+    TraingleMesh::VertexIndices vi;
+    for (std::vector<uint32_t>::const_iterator vidx = vertices.begin(), viend = vertices.end();
+         vidx != viend; ++vidx)
+    {
+      //      mesh_index_map2.left.count
+      if (!mesh_index_map.left.count(*vidx))
+      {
+        mesh_index_map.insert(MeshIndexMap::value_type(*vidx, mesh.addVertex(*vidx)));
+      }
+      vi.push_back(mesh_index_map.left.at(*vidx));
+    }
+    mesh.addFace(vi.at(0), vi.at(1), vi.at(2));
+  }
+
+  return mesh;
+}
+
+/** \brief Get a collection of boundary half-edges for the input mesh.
+  * \param[in] mesh The input mesh.
+  * \param[out] boundary_he_collection Collection of boundary half-edges. Each element in the vector
+ * is one connected boundary. The whole boundary is the union of all elements.
+  * \param [in] expected_size If you already know the size of the longest boundary you can tell this
+ * here. Defaults to 3 (minimum possible boundary).
+  * \author Martin Saelzle
+  * \ingroup geometry
+  */
+template <class MeshT>
+void getBoundBoundaryHalfEdges(const MeshT& mesh,
+                               std::vector<typename MeshT::HalfEdgeIndices>& boundary_he_collection,
+                               const size_t expected_size = 3)
+{
+  typedef MeshT Mesh;
+  typedef typename Mesh::HalfEdgeIndex HalfEdgeIndex;
+  typedef typename Mesh::HalfEdgeIndices HalfEdgeIndices;
+  typedef typename Mesh::InnerHalfEdgeAroundFaceCirculator IHEAFC;
+
+  boundary_he_collection.clear();
+
+  HalfEdgeIndices boundary_he;
+  boundary_he.reserve(expected_size);
+  std::vector<bool> visited(mesh.sizeEdges(), false);
+  IHEAFC circ, circ_end;
+
+  for (HalfEdgeIndex i(0); i < HalfEdgeIndex(mesh.sizeHalfEdges()); ++i)
+  {
+    if (mesh.isBoundary(i) && !visited[pcl::geometry::toEdgeIndex(i).get()])
+    {
+      boundary_he.clear();
+
+      circ = mesh.getInnerHalfEdgeAroundFaceCirculator(i);
+      circ_end = circ;
+      do
+      {
+        visited[pcl::geometry::toEdgeIndex(circ.getTargetIndex()).get()] = true;
+        boundary_he.push_back(circ.getTargetIndex());
+      } while (++circ != circ_end);
+
+      boundary_he_collection.push_back(boundary_he);
+    }
+  }
+}
+
+bool decimate(const pcl::PointCloud<pcl::PointNormal>& in, pcl::PointCloud<pcl::PointNormal>& out, double min_point_dist)
+{
+   out.clear();
+   out.push_back(in[0]);
+   using PType = std::remove_reference<decltype(in)>::type::PointType;
+   for(std::size_t i = 1 ; i < in.size() - 1; i++)
+   {
+     const PType& p = in[i];
+
+     double dist = (out.back().getVector3fMap() - p.getVector3fMap()).norm();
+     if(dist > min_point_dist)
+     {
+       out.push_back(p);
+     }
+   }
+   out.push_back(in.back());
+   return out.size() > 2;
+}
+
+namespace tool_path_planner
+{
+HalfEdgeBoundaryFinder::HalfEdgeBoundaryFinder()
+{
+
+}
+
+HalfEdgeBoundaryFinder::~HalfEdgeBoundaryFinder()
+{
+
+}
+
+void HalfEdgeBoundaryFinder::setInput(pcl::PolygonMesh::ConstPtr mesh)
+{
+  mesh_ = mesh;
+}
+
+void HalfEdgeBoundaryFinder::setInput(const shape_msgs::Mesh& mesh)
+{
+  pcl::PolygonMesh::Ptr pcl_mesh = boost::make_shared<pcl::PolygonMesh>();
+  noether_conversions::convertToPCLMesh(mesh,*pcl_mesh);
+  setInput(pcl_mesh);
+}
+
+boost::optional<std::vector<geometry_msgs::PoseArray> >
+HalfEdgeBoundaryFinder::generate(const tool_path_planner::HalfEdgeBoundaryFinder::Config& config)
+{
+  using namespace pcl;
+  CONSOLE_BRIDGE_logInform("Input mesh has %lu polygons",mesh_->polygons.size());
+  boost::optional<TraingleMesh> mesh = createTriangleMesh(*mesh_);
+  if(!mesh)
+  {
+    CONSOLE_BRIDGE_logError("Failed to create triangle mesh");
+    return boost::none;
+  }
+
+  if(mesh->getVertexDataCloud().empty())
+  {
+    CONSOLE_BRIDGE_logError("Generated Triangle mesh contains no data");
+    return boost::none;
+  }
+
+  std::vector<TraingleMesh::HalfEdgeIndices> boundary_he_indices;
+  getBoundBoundaryHalfEdges(mesh.get(), boundary_he_indices);
+
+  // initializing octree
+  PointCloud<PointNormal>::Ptr input_cloud = boost::make_shared<PointCloud<PointNormal>>();
+  PointCloud<PointXYZ>::Ptr input_points = boost::make_shared<PointCloud<PointXYZ>>();
+  noether_conversions::convertToPointNormals(*mesh_, *input_cloud);
+  pcl::copyPointCloud(*input_cloud, *input_points );
+
+
+  pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
+  kdtree.setInputCloud (input_points);
+
+  // traversing half edges list
+  std::vector<geometry_msgs::PoseArray> boundary_poses;
+
+
+  for (std::vector<TraingleMesh::HalfEdgeIndices>::const_iterator boundary = boundary_he_indices.begin(),
+                                                                  b_end = boundary_he_indices.end();
+       boundary != b_end; ++boundary)
+  {
+    geometry_msgs::PoseArray bound_segment_poses;
+    PointCloud<PointNormal> bound_segment_points;
+    for (TraingleMesh::HalfEdgeIndices::const_iterator edge = boundary->begin(), edge_end = boundary->end();
+         edge != edge_end; ++edge)
+    {
+      TraingleMesh::VertexIndex vertex = mesh->getOriginatingVertexIndex(*edge);
+      if(mesh->getVertexDataCloud().size() <= vertex.get())
+      {
+        CONSOLE_BRIDGE_logError("Vertex index exceeds size of vertex list");
+        return boost::none;
+      }
+      std::size_t source_idx = mesh->getVertexDataCloud()[vertex.get()];
+
+      if(input_cloud->size() <= source_idx)
+      {
+        CONSOLE_BRIDGE_logError("Point index exceeds size of mesh point cloud");
+        return boost::none;
+      }
+
+      bound_segment_points.push_back((*input_cloud)[source_idx]);
+    }
+
+    if(config.min_point_dist >  1e-6 )
+    {
+
+      decltype(bound_segment_points) decimated_points;
+      if(!decimate(bound_segment_points, decimated_points, config.min_point_dist))
+      {
+        CONSOLE_BRIDGE_logDebug("Decimation failed, ignoring segment");
+        continue;
+      }
+      bound_segment_points = std::move(decimated_points);
+    }
+
+    if(!createPoseArray(bound_segment_points,{},bound_segment_poses))
+    {
+      return boost::none;
+    }
+
+    boundary_poses.push_back(bound_segment_poses);
+  }
+
+  // sorting
+  CONSOLE_BRIDGE_logInform("Found %lu boundary segments, removing invalid ones", boundary_poses.size());
+  std::sort(boundary_poses.begin(), boundary_poses.end(),[](decltype(boundary_poses)::value_type& p1,
+      decltype(boundary_poses)::value_type& p2){
+    return p1.poses.size() >  p2.poses.size();
+  });
+
+  // erase
+  decltype(boundary_poses)::iterator last = std::remove_if(boundary_poses.begin(), boundary_poses.end(),
+                                                           [&config](decltype(boundary_poses)::value_type& p){
+    return p.poses.size() < config.min_num_points;
+  });
+  boundary_poses.erase(last,boundary_poses.end());
+  if(boundary_poses.empty())
+  {
+    CONSOLE_BRIDGE_logError("No valid boundary segments were found, original mesh may have duplicate vertices");
+    return boost::none;
+  }
+
+  CONSOLE_BRIDGE_logInform("Found %lu valid boundary segments", boundary_poses.size());
+  return boundary_poses;
+}
+
+} /* namespace tool_path_planner */

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -34,6 +34,7 @@
 #include <vtkGenericCell.h>
 #include <vtkTriangleFilter.h>
 #include <tool_path_planner/utilities.h>
+#include <console_bridge/console.h>
 
 namespace tool_path_planner
 {
@@ -244,6 +245,60 @@ Eigen::Matrix3d toRotationMatrix(const Eigen::Vector3d& vx, const Eigen::Vector3
   rot.block(1,0,1,3) = Vector3d(vx.y(), vy.y(), vz.y()).array().transpose();
   rot.block(2,0,1,3) = Vector3d(vx.z(), vy.z(), vz.z()).array().transpose();
   return rot;
+}
+
+
+bool createPoseArray(const pcl::PointCloud<pcl::PointNormal>& cloud_normals, const std::vector<int>& indices,
+                     geometry_msgs::PoseArray& poses)
+{
+  using namespace pcl;
+  using namespace Eigen;
+
+  geometry_msgs::Pose pose_msg;
+  Isometry3d pose;
+  Vector3d x_dir, z_dir, y_dir;
+  std::vector<int> cloud_indices;
+  if(indices.empty())
+  {
+    cloud_indices.resize(cloud_normals.size());
+    std::iota(cloud_indices.begin(), cloud_indices.end(), 0);
+  }
+  else
+  {
+    cloud_indices.assign(indices.begin(), indices.end());
+  }
+
+  for(std::size_t i = 0; i < cloud_indices.size() - 1; i++)
+  {
+    std::size_t idx_current = cloud_indices[i];
+    std::size_t idx_next = cloud_indices[i+1];
+    if(idx_current >= cloud_normals.size() || idx_next >= cloud_normals.size())
+    {
+      CONSOLE_BRIDGE_logError("Invalid indices (current: %lu, next: %lu) for point cloud were passed",
+                              idx_current, idx_next);
+      return false;
+    }
+    const PointNormal& p1 = cloud_normals[idx_current];
+    const PointNormal& p2 = cloud_normals[idx_next];
+    x_dir = (p2.getVector3fMap() - p1.getVector3fMap()).normalized().cast<double>();
+    z_dir = Vector3d(p1.normal_x, p1.normal_y, p1.normal_z).normalized();
+    y_dir = z_dir.cross(x_dir).normalized();
+
+    pose = Translation3d(p1.getVector3fMap().cast<double>());
+    pose.matrix().block<3,3>(0,0) = tool_path_planner::toRotationMatrix(x_dir, y_dir, z_dir);
+    tf::poseEigenToMsg(pose,pose_msg);
+
+    poses.poses.push_back(pose_msg);
+  }
+
+  // last pose
+  pose_msg = poses.poses.back();
+  pose_msg.position.x = cloud_normals[cloud_indices.back()].x;
+  pose_msg.position.y = cloud_normals[cloud_indices.back()].y;
+  pose_msg.position.z = cloud_normals[cloud_indices.back()].z;
+  poses.poses.push_back(pose_msg);
+
+  return true;
 }
 
 }


### PR DESCRIPTION
This PR adds a new capability which computes the edges by collecting the halfedges from the mesh. It's far more robust than the current method which uses covariance computation and requires less tuning.  It needs a mesh without duplicate points.  In a subsequent PR I'll add a simplification filter that removes duplicate points from a mesh but for now this should work as long a proper mesh is passed.  
Run the demo as follows
```
roslaunch noether_examples halfedge_finder_demo.launch
```