### PR TITLE
Feature new mesh filters

### DIFF
--- a/noether/config/mesh_filter_manager.yaml
+++ b/noether/config/mesh_filter_manager.yaml
@@ -3,12 +3,29 @@ filter_groups:
     continue_on_failure: False
     verbosity_on: True
     filters:
+    - type: noether_filtering/CleanData
+      name: clean_data_1
+      config: {}
     - type: noether_filtering/EuclideanClustering
-      name: clustering_1
+      name: clustering_filter_1
       config:
         tolerance: 0.006
         min_cluster_size: 3000
-        max_cluster_size: -1   # will use input point cloud size when negative    
+        max_cluster_size: -1   # will use input point cloud size when negative  
+    - type: noether_filtering/WindowedSincSmoothing
+      name: smoothing_1
+      config: 
+        num_iter: 100
+        enable_boundary_smoothing: true
+        enable_feature_edge_smoothing: false
+        enable_non_manifold_smoothing: true
+        enable_normalize_coordinates: true
+        feature_angle: 10.0
+        edge_angle: 150.0
+        pass_band: 0.01 
+    - type: noether_filtering/CleanData
+      name: clean_data_2
+      config: {}
   - group_name: DEFAULT
     continue_on_failure: False
     verbosity_on: True

--- a/noether_filtering/CMakeLists.txt
+++ b/noether_filtering/CMakeLists.txt
@@ -64,6 +64,7 @@ if(${BUILD_MESH_PLUGINS})
     src/mesh/bspline_reconstruction.cpp
     src/mesh/euclidean_clustering.cpp
     src/mesh/clean_data.cpp
+    src/mesh/windowed_sinc_smoothing.cpp
   )
   target_link_libraries(${PROJECT_NAME}_mesh_filters PUBLIC ${PROJECT_NAME})
   target_include_directories(${PROJECT_NAME}_mesh_filters PUBLIC

--- a/noether_filtering/CMakeLists.txt
+++ b/noether_filtering/CMakeLists.txt
@@ -63,6 +63,7 @@ if(${BUILD_MESH_PLUGINS})
   add_library(${PROJECT_NAME}_mesh_filters SHARED
     src/mesh/bspline_reconstruction.cpp
     src/mesh/euclidean_clustering.cpp
+    src/mesh/clean_data.cpp
   )
   target_link_libraries(${PROJECT_NAME}_mesh_filters PUBLIC ${PROJECT_NAME})
   target_include_directories(${PROJECT_NAME}_mesh_filters PUBLIC

--- a/noether_filtering/include/noether_filtering/mesh/clean_data.h
+++ b/noether_filtering/include/noether_filtering/mesh/clean_data.h
@@ -1,0 +1,63 @@
+/**
+ * @author Jorge Nicho <jrgnichodevel@gmail.com>
+ * @file clean_data.h
+ * @date Dec 6, 2019
+ * @copyright Copyright (c) 2019, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef INCLUDE_NOETHER_FILTERING_MESH_CLEAN_DATA_H_
+#define INCLUDE_NOETHER_FILTERING_MESH_CLEAN_DATA_H_
+
+#include "noether_filtering/mesh/mesh_filter_base.h"
+
+namespace noether_filtering
+{
+namespace mesh
+{
+/**
+ * @class noether_filtering::mesh::CleanData
+ * @details Uses the VTK capability shown in this example https://lorensen.github.io/VTKExamples/site/Cxx/PolyData/CleanPolyData/
+ *          Merges duplicate points, and/or remove unused points and/or remove degenerate cells
+ */
+class CleanData : public MeshFilterBase
+{
+public:
+  CleanData();
+  virtual ~CleanData();
+
+  /**
+   * @brief does not require configuration
+   * @param config Here to conform to interface but can be an emtpy object
+   * @return  True always
+   */
+  bool configure(XmlRpc::XmlRpcValue config) override final;
+
+  /**
+   * @brief Merges duplicate points, and/or remove unused points and/or remove degenerate cells
+   * @param mesh_in
+   * @param mesh_out
+   * @return True always
+   */
+  bool filter(const pcl::PolygonMesh& mesh_in, pcl::PolygonMesh& mesh_out) override final;
+  std::string getName() const override final;
+
+};
+
+} /* namespace mesh */
+} /* namespace noether_filtering */
+
+#endif /* INCLUDE_NOETHER_FILTERING_MESH_CLEAN_DATA_H_ */

--- a/noether_filtering/include/noether_filtering/mesh/windowed_sinc_smoothing.h
+++ b/noether_filtering/include/noether_filtering/mesh/windowed_sinc_smoothing.h
@@ -1,0 +1,71 @@
+/*
+ * window_sinc_smoothing.h
+ *
+ *  Created on: Dec 6, 2019
+ *      Author: jrgnicho
+ */
+
+#ifndef SRC_MESH_WINDOW_SINC_SMOOTHING_H_
+#define SRC_MESH_WINDOW_SINC_SMOOTHING_H_
+
+#include "noether_filtering/mesh/mesh_filter_base.h"
+
+namespace noether_filtering
+{
+namespace mesh
+{
+/**
+ * @class noether_filtering:;mesh::WindowedSincSmoothing
+ * @details uses the vtkWindowedSincPolyDataFilter to smooth out the mesh, details of the implementation
+ * and the configuration parameters can be found here https://vtk.org/doc/nightly/html/classvtkWindowedSincPolyDataFilter.html
+ */
+class WindowedSincSmoothing : public MeshFilterBase
+{
+public:
+  struct Config
+  {
+    std::size_t num_iter = 100;
+    bool enable_boundary_smoothing = true;       /**@brief Set to true to enable */
+    bool enable_feature_edge_smoothing = false;  /**@brief Set to true to enable */
+    bool enable_non_manifold_smoothing = true;   /**@brief Set to true to enable */
+    bool enable_normalize_coordinates = true;    /**@brief Set to true to enable */
+    double feature_angle = 10.0;          /**@brief degrees, only applicable when feature_edge_smoothing = true */
+    double edge_angle = 150.0;            /**@brief degrees, only applicable when feature_edge_smoothing = true */
+    double pass_band = 0.01;
+
+  };
+
+  WindowedSincSmoothing();
+  virtual ~WindowedSincSmoothing();
+
+  /**
+   * @details Loads a configuration from yaml of the following form:
+   *
+   * num_iter: 100
+   * enable_boundary_smoothing: true
+   * enable_feature_edge_smoothing: false
+   * enable_non_manifold_smoothing: true
+   * enable_normalize_coordinates: true
+   * feature_angle: 10.0
+   * edge_angle: 150.0
+   * pass_band: 0.01
+   *
+   * @param config
+   * @return
+   */
+  bool configure(XmlRpc::XmlRpcValue config) override final;
+
+  bool filter(const pcl::PolygonMesh& mesh_in, pcl::PolygonMesh& mesh_out) override final;
+
+  std::string getName() const override final;
+
+private:
+
+  Config config_;
+
+};
+
+} /* namespace mesh */
+} /* namespace noether_filtering */
+
+#endif /* SRC_MESH_WINDOW_SINC_SMOOTHING_H_ */

--- a/noether_filtering/include/noether_filtering/mesh/windowed_sinc_smoothing.h
+++ b/noether_filtering/include/noether_filtering/mesh/windowed_sinc_smoothing.h
@@ -31,7 +31,7 @@ public:
     bool enable_normalize_coordinates = true;    /**@brief Set to true to enable */
     double feature_angle = 10.0;          /**@brief degrees, only applicable when feature_edge_smoothing = true */
     double edge_angle = 150.0;            /**@brief degrees, only applicable when feature_edge_smoothing = true */
-    double pass_band = 0.01;
+    double pass_band = 0.01;              /**@brief PassBand for the windowed sinc filter, see explanation in reference link */
 
   };
 
@@ -55,8 +55,18 @@ public:
    */
   bool configure(XmlRpc::XmlRpcValue config) override final;
 
+  /**
+   * @brief applies the filtering method
+   * @param mesh_in   Input mesh
+   * @param mesh_out  Output mesh
+   * @return True on success, false otherwise
+   */
   bool filter(const pcl::PolygonMesh& mesh_in, pcl::PolygonMesh& mesh_out) override final;
 
+  /**
+   * @brief returns the type name of the filter
+   * @return  A string containing the filter type name
+   */
   std::string getName() const override final;
 
 private:

--- a/noether_filtering/mesh_filter_plugins.xml
+++ b/noether_filtering/mesh_filter_plugins.xml
@@ -16,7 +16,17 @@
   <class name="noether_filtering/CleanData" type="noether_filtering::mesh::CleanData"
     base_class_type="noether_filtering::mesh::MeshFilterBase">
     <description>
-      Merges duplicate points, and/or remove unused points and/or remove degenerate cells
+      Merges duplicate points, and/or remove unused points and/or remove degenerate cells using VTK,
+      see https://vtk.org/doc/nightly/html/classvtkCleanPolyData.html#details for more details
+    </description>
+  </class>
+  
+    <class name="noether_filtering/WindowedSincSmoothing" type="noether_filtering::mesh::WindowedSincSmoothing"
+    base_class_type="noether_filtering::mesh::MeshFilterBase">
+    <description>
+      Adjust point positions using a windowed sinc function interpolation kernel using VTK see 
+      https://vtk.org/doc/nightly/html/classvtkWindowedSincPolyDataFilter.html#details for 
+      more details
     </description>
   </class>
 </library>

--- a/noether_filtering/mesh_filter_plugins.xml
+++ b/noether_filtering/mesh_filter_plugins.xml
@@ -5,10 +5,18 @@
       Fits a nurve surface to a polygonal mesh and clips the boundaries if requested
     </description>
   </class>
+  
   <class name="noether_filtering/EuclideanClustering" type="noether_filtering::mesh::EuclideanClustering"
     base_class_type="noether_filtering::mesh::MeshFilterBase">
     <description>
       Runs euclidean clustering and removes all the points that don't fit the constraints
+    </description>
+  </class>
+  
+  <class name="noether_filtering/CleanData" type="noether_filtering::mesh::CleanData"
+    base_class_type="noether_filtering::mesh::MeshFilterBase">
+    <description>
+      Merges duplicate points, and/or remove unused points and/or remove degenerate cells
     </description>
   </class>
 </library>

--- a/noether_filtering/src/mesh/clean_data.cpp
+++ b/noether_filtering/src/mesh/clean_data.cpp
@@ -1,0 +1,65 @@
+/*
+ * clean_data.cpp
+ *
+ *  Created on: Dec 6, 2019
+ *      Author: jrgnicho
+ */
+
+#include <XmlRpcException.h>
+#include <vtkSmartPointer.h>
+#include <vtkPolyData.h>
+#include <vtkCleanPolyData.h>
+#include <pcl/surface/vtk_smoothing/vtk_utils.h>
+#include <console_bridge/console.h>
+#include "noether_filtering/mesh/clean_data.h"
+#include "noether_filtering/utils.h"
+
+namespace noether_filtering
+{
+namespace mesh
+{
+CleanData::CleanData()
+{
+
+}
+
+CleanData::~CleanData()
+{
+
+}
+
+bool CleanData::configure(XmlRpc::XmlRpcValue config)
+{
+  // no configuration needed
+  return true;
+}
+
+bool CleanData::filter(const pcl::PolygonMesh& mesh_in, pcl::PolygonMesh& mesh_out)
+{
+  using namespace pcl;
+
+  vtkSmartPointer<vtkPolyData> mesh_data = vtkSmartPointer<vtkPolyData>::New();
+  VTKUtils::mesh2vtk(mesh_in, mesh_data);
+  std::size_t num_start_points = mesh_data->GetNumberOfPoints();
+
+  mesh_data->BuildCells();
+  mesh_data->BuildLinks();
+
+  vtkSmartPointer<vtkCleanPolyData> cleanPolyData = vtkSmartPointer<vtkCleanPolyData>::New();
+  cleanPolyData->SetInputData(mesh_data);
+  cleanPolyData->Update();
+  mesh_data = cleanPolyData->GetOutput();
+  std::size_t num_end_points = mesh_data->GetNumberOfPoints();
+  CONSOLE_BRIDGE_logInform("Removed duplicate points, retained %lu points from %lu",
+                           num_end_points, num_start_points);
+  VTKUtils::vtk2mesh(mesh_data,mesh_out);
+  return true;
+}
+
+std::string CleanData::getName() const
+{
+  return utils::getClassName<decltype(*this)>();
+}
+
+} /* namespace mesh */
+} /* namespace noether_filtering */

--- a/noether_filtering/src/mesh/plugins.cpp
+++ b/noether_filtering/src/mesh/plugins.cpp
@@ -4,7 +4,9 @@
 #include "noether_filtering/mesh/bspline_reconstruction.h"
 #include "noether_filtering/mesh/euclidean_clustering.h"
 #include "noether_filtering/mesh/clean_data.h"
+#include "noether_filtering/mesh/windowed_sinc_smoothing.h"
 
 PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::BSplineReconstruction, noether_filtering::mesh::MeshFilterBase)
 PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::EuclideanClustering, noether_filtering::mesh::MeshFilterBase)
 PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::CleanData, noether_filtering::mesh::MeshFilterBase)
+PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::WindowedSincSmoothing, noether_filtering::mesh::MeshFilterBase)

--- a/noether_filtering/src/mesh/plugins.cpp
+++ b/noether_filtering/src/mesh/plugins.cpp
@@ -3,6 +3,8 @@
 // Mesh filters
 #include "noether_filtering/mesh/bspline_reconstruction.h"
 #include "noether_filtering/mesh/euclidean_clustering.h"
+#include "noether_filtering/mesh/clean_data.h"
 
 PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::BSplineReconstruction, noether_filtering::mesh::MeshFilterBase)
 PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::EuclideanClustering, noether_filtering::mesh::MeshFilterBase)
+PLUGINLIB_EXPORT_CLASS(noether_filtering::mesh::CleanData, noether_filtering::mesh::MeshFilterBase)

--- a/noether_filtering/src/mesh/windowed_sinc_smoothing.cpp
+++ b/noether_filtering/src/mesh/windowed_sinc_smoothing.cpp
@@ -1,0 +1,111 @@
+/*
+ * window_sinc_smoothing.cpp
+ *
+ *  Created on: Dec 6, 2019
+ *      Author: jrgnicho
+ */
+
+#include <XmlRpcException.h>
+#include <vtkSmartPointer.h>
+#include <vtkPolyData.h>
+#include <vtkWindowedSincPolyDataFilter.h>
+#include <pcl/surface/vtk_smoothing/vtk_utils.h>
+#include <console_bridge/console.h>
+#include "noether_filtering/utils.h"
+#include "noether_filtering/mesh/windowed_sinc_smoothing.h"
+
+namespace noether_filtering
+{
+namespace mesh
+{
+WindowedSincSmoothing::WindowedSincSmoothing()
+{
+
+}
+
+WindowedSincSmoothing::~WindowedSincSmoothing()
+{
+
+}
+
+bool WindowedSincSmoothing::configure(XmlRpc::XmlRpcValue config)
+{
+  std::vector<std::string> fields = {"num_iter",
+                                     "enable_boundary_smoothing",
+                                     "enable_feature_edge_smoothing",
+                                     "enable_non_manifold_smoothing",
+                                     "enable_normalize_coordinates",
+                                     "feature_angle",
+                                     "edge_angle",
+                                     "pass_band",
+                                     };
+
+  if(!std::all_of(fields.begin(), fields.end(), [&config, this](const std::string& f){
+    if( !config.hasMember(f))
+    {
+      CONSOLE_BRIDGE_logError("The %s config field %s was not found", getName().c_str(), f.c_str());
+      return false;
+    }
+    return true;
+  }
+  ))
+  {
+    return false;
+  }
+
+  try
+  {
+    std::size_t idx = 0;
+    config_.num_iter = static_cast<int>(config[fields[idx++]]);
+    config_.enable_boundary_smoothing = static_cast<bool>(config[fields[idx++]]);
+    config_.enable_feature_edge_smoothing = static_cast<bool>(config[fields[idx++]]);
+    config_.enable_non_manifold_smoothing = static_cast<bool>(config[fields[idx++]]);
+    config_.enable_normalize_coordinates = static_cast<bool>(config[fields[idx++]]);
+    config_.feature_angle = static_cast<double>(config[fields[idx++]]);
+    config_.edge_angle = static_cast<double>(config[fields[idx++]]);
+    config_.pass_band = static_cast<double>(config[fields[idx++]]);
+  }
+  catch(XmlRpc::XmlRpcException& e)
+  {
+    CONSOLE_BRIDGE_logError(e.getMessage().c_str());
+    return false;
+  }
+  return true;
+}
+
+bool WindowedSincSmoothing::filter(const pcl::PolygonMesh& mesh_in, pcl::PolygonMesh& mesh_out)
+{
+  using namespace pcl;
+
+  vtkSmartPointer<vtkPolyData> mesh_data = vtkSmartPointer<vtkPolyData>::New();
+  VTKUtils::mesh2vtk(mesh_in, mesh_data);
+  std::size_t num_start_points = mesh_data->GetNumberOfPoints();
+
+  mesh_data->BuildCells();
+  mesh_data->BuildLinks();
+
+  vtkSmartPointer<vtkWindowedSincPolyDataFilter> smoother = vtkSmartPointer<vtkWindowedSincPolyDataFilter>::New();
+  smoother->SetInputData(mesh_data);
+  smoother->SetNumberOfIterations(config_.num_iter);
+  smoother->SetFeatureAngle(config_.feature_angle);
+  smoother->SetEdgeAngle(config_.edge_angle);
+  smoother->SetPassBand(config_.pass_band);
+  smoother->SetBoundarySmoothing(config_.enable_boundary_smoothing);
+  smoother->SetFeatureEdgeSmoothing(config_.enable_feature_edge_smoothing);
+  smoother->SetNonManifoldSmoothing(config_.enable_non_manifold_smoothing);
+  smoother->SetNormalizeCoordinates(config_.enable_normalize_coordinates);
+  smoother->Update();
+  smoother->PrintSelf(std::cout,vtkIndent(1));
+
+  mesh_data = smoother->GetOutput();
+  VTKUtils::vtk2mesh(mesh_data,mesh_out);
+  return true;
+}
+
+std::string WindowedSincSmoothing::getName() const
+{
+  return utils::getClassName<decltype(*this)>();
+}
+
+} /* namespace mesh */
+} /* namespace noether_filtering */

--- a/noether_filtering/src/mesh/windowed_sinc_smoothing.cpp
+++ b/noether_filtering/src/mesh/windowed_sinc_smoothing.cpp
@@ -95,7 +95,6 @@ bool WindowedSincSmoothing::filter(const pcl::PolygonMesh& mesh_in, pcl::Polygon
   smoother->SetNonManifoldSmoothing(config_.enable_non_manifold_smoothing);
   smoother->SetNormalizeCoordinates(config_.enable_normalize_coordinates);
   smoother->Update();
-  smoother->PrintSelf(std::cout,vtkIndent(1));
 
   mesh_data = smoother->GetOutput();
   VTKUtils::vtk2mesh(mesh_data,mesh_out);


### PR DESCRIPTION
This PR adds 2 mesh filter plugins that do the following
- Clean Data: Removes duplicate points and rectifies degenerate artifacts among other things.
- WindowedSincSmoother: Smooths out noisy meshes

The **Simplification** filter group listed in the `noether/config/mesh_filter_manager.yaml` was used

```
roslaunch noether_examples mesh_filtering_demo.launch filter_group:=Simplification
```

Requires PR #73 
