### PR TITLE
Feature edge path equal spacing

### DIFF
--- a/noether/config/halfedge_boundary_finder.yaml
+++ b/noether/config/halfedge_boundary_finder.yaml
@@ -1,5 +1,6 @@
 min_num_points: 50
-min_point_dist: 0.02
+point_spacing_method: 2 # NONE= 0, MIN_DISTANCE = 1, EQUAL_SPACING = 2, PARAMETRIC_SPLINE = 3 
+point_dist: 0.02
 normal_averaging: True
 normal_search_radius: 0.1
 normal_influence_weight: 1.0

--- a/noether/config/mesh_filter_manager.yaml
+++ b/noether/config/mesh_filter_manager.yaml
@@ -10,7 +10,7 @@ filter_groups:
       name: clustering_filter_1
       config:
         tolerance: 0.006
-        min_cluster_size: 3000
+        min_cluster_size: 50000
         max_cluster_size: -1   # will use input point cloud size when negative  
     - type: noether_filtering/WindowedSincSmoothing
       name: smoothing_1

--- a/noether_examples/launch/surf_raster_planner_application.launch
+++ b/noether_examples/launch/surf_raster_planner_application.launch
@@ -2,10 +2,12 @@
   <arg name="filename"/>
   <arg name="tool" default="$(find noether)/config/tool.yaml"/>
 
-  <node name="noether" type="surface_raster_planner_application" pkg="noether" output="screen" required="true">
+  <node name="surface_raster_planner_demo" type="surface_raster_planner_application" pkg="noether" output="screen" required="true">
     <!--Loads a particular test file: pcd or stl -->
     <param name="filename" value="$(arg filename)" type="string"/>
     <rosparam command="load" file="$(arg tool)"/>
   </node>
+  
+  
 
 </launch>

--- a/noether_filtering/src/mesh/euclidean_clustering.cpp
+++ b/noether_filtering/src/mesh/euclidean_clustering.cpp
@@ -94,7 +94,11 @@ bool EuclideanClustering::filter(const pcl::PolygonMesh& mesh_in, pcl::PolygonMe
     CONSOLE_BRIDGE_logError("%s found no clusters", getName().c_str());
     return false;
   }
+
   CONSOLE_BRIDGE_logInform("%s found %lu clusters",getName().c_str(),cluster_indices.size());
+  std::for_each(cluster_indices.begin(),cluster_indices.end(),[idx = 0](decltype(cluster_indices)::value_type& c) mutable{
+    CONSOLE_BRIDGE_logInform("\t cluster[%i] -> %lu points ",idx++,c.indices.size());
+  });
 
 
   // accumulate all cluster indices into one

--- a/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
+++ b/tool_path_planner/include/tool_path_planner/half_edge_boundary_finder.h
@@ -39,14 +39,25 @@ class HalfEdgeBoundaryFinder
 {
 public:
 
+  enum PointSpacingMethod: int
+  {
+    NONE = 0,
+    MIN_DISTANCE = 1,
+    EQUAL_SPACING,
+    PARAMETRIC_SPLINE
+  };
+
   struct Config
   {
     std::size_t min_num_points = 200;     /**@brief only edge segments with more than this many points will be returned*/
-    double min_point_dist = 0.01;         /**@brief minimum distance for adjacent points, set to < 0 to turn off this constraint */
     bool normal_averaging = true;         /**@brief True in order set the normal of each point as the average of the normal vectors
                                                   of the points within a specified radius*/
     double normal_search_radius = 0.02;   /**@brief The search radius used for normal averaging */
-    double normal_influence_weight = 0.5; /**@brief A value [0, 1] that influences the normal averaged based on its distance, set to 0 to disable */
+    double normal_influence_weight = 0.5; /**@brief A value [0, 1] that influences the normal averaged based on its distance,
+                                                    set to 0 to disable */
+    PointSpacingMethod point_spacing_method = PointSpacingMethod::EQUAL_SPACING; /**@brief the method used for spacing the points,
+                                                   NONE = 0, MIN_DISTANCE = 1, EQUAL_SPACING = 2, PARAMETRIC_SPLINE = 3 */
+    double point_dist = 0.01;         /**@brief point distance parameter used in conjunction with the spacing method */
   };
 
   HalfEdgeBoundaryFinder();

--- a/tool_path_planner/src/halfedge_boundary_finder.cpp
+++ b/tool_path_planner/src/halfedge_boundary_finder.cpp
@@ -182,7 +182,7 @@ bool applyEqualDistance(const pcl::PointCloud<pcl::PointNormal>& in, pcl::PointC
     v_2 = p_end.getVector3fMap() - p_mid.getVector3fMap();
     if(dist < (v_1 + v_2).norm())
     {
-      // solve for x such that " x^2 + 2 * x * dot(v_1, unitv_2) + norm(v_1)^2 - d^2 "
+      // solve for x such that " x^2 + 2 * x * dot(v_1, unitv_2) + norm(v_1)^2 - d^2 = 0"
       unitv_2 = v_2.normalized();
       double b = 2 * v_1.dot(unitv_2);
       double c = std::pow(v_1.norm(),2) - std::pow(dist,2);
@@ -518,7 +518,6 @@ HalfEdgeBoundaryFinder::generate(const tool_path_planner::HalfEdgeBoundaryFinder
                                bound_segment_points.size(), decimated_points.size());
       bound_segment_points = std::move(decimated_points);
     }
-
 
     if(bound_segment_points.size() < config.min_num_points)
     {


### PR DESCRIPTION
This PR adds the ability to enforce equal spacing between adjacent points in the edge path generated by the halfedge boundary finder