### PR TITLE
Export cmake build type to fix build error with other packages

### DIFF
--- a/vtk_viewer/package.xml
+++ b/vtk_viewer/package.xml
@@ -12,5 +12,9 @@
   <depend>libpcl-all-dev</depend>
 
   <test_depend>rosunit</test_depend>
+  
+  <export>
+	  <build_type> cmake </build_type>
+  </export>
 
 </package>


### PR DESCRIPTION
Without this export entry packages that depend on vtk_viewer fail to compile