### PR TITLE
CMake error on first build

### DIFF
--- a/noether_filtering/CMakeLists.txt
+++ b/noether_filtering/CMakeLists.txt
@@ -21,22 +21,6 @@ find_package(console_bridge REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(xmlrpcpp REQUIRED)
 
-# Check if PCL was compiled with OpenNURBS
-if(NOT DEFINED NURBS_FOUND)
-    try_compile(
-        NURBS_FOUND
-        ${CMAKE_CURRENT_BINARY_DIR}/pcl_nurbs_try_compile
-        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test_scripts/check_pcl_nurbs.cpp
-        CMAKE_FLAGS ${CMAKE_FLAGS} -DINCLUDE_DIRECTORIES=${PCL_INCLUDE_DIRS}
-        LINK_LIBRARIES ${PCL_LIBRARIES}
-        )
-    if (NOT ${NURBS_FOUND})
-        message("PCL NURBS NOT FOUND")
-    else()
-        message("PCL NURBS FOUND")
-    endif()
-endif()
-
 ###########
 ## Build ##
 ###########


### PR DESCRIPTION
When building the `noether` package for the first time (or after cleaning the workspace) it fails with the following errors as mentioned in https://github.com/ros-industrial/noether/issues/98#issuecomment-665186608:

```
Errors     << noether_filtering:cmake /catkin_ws/logs/noether_filtering/build.cmake.000.log                                                                                              
CMake Error:
  Error evaluating generator expression:

    $<COMPILE_LANGUAGE:CXX>

  $<COMPILE_LANGUAGE:...> may only be used to specify include directories,
  compile definitions, compile options, and to evaluate components of the
  file(GENERATE) command.

...

PCL NURBS FOUND
Building mesh plugins
cd /catkin_ws/build/noether_filtering; catkin build --get-env noether_filtering | catkin env -si  /usr/bin/cmake /catkin_ws/src/noether/noether_filtering --no-warn-unused-cli -DCMAKE_INSTALL_PREFIX=/catkin_ws/devel; cd -
```
Running `catkin build` again then allows `noether` to build successfully. In https://github.com/ros-industrial/noether/issues/98#issuecomment-666389690 it is advised to try the fix implemented in this PR, which solves the first build issue. 
