### PR TITLE
Use Float Literals to Fix Build Error on Ubuntu 20.04 / ROS Noetic

### DIFF
--- a/noether_conversions/include/noether_conversions/noether_conversions.h
+++ b/noether_conversions/include/noether_conversions/noether_conversions.h
@@ -91,8 +91,8 @@ namespace noether_conversions {
                                                       const std::size_t& start_id = 1,
                                                       const std::tuple<float, float, float, float, float, float>& offset = std::make_tuple(
                                                           0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-                                                      const float& line_width = 0.001,
-                                                      const float& point_size = 0.005);
+                                                      const float& line_width = 0.001f,
+                                                      const float& point_size = 0.005f);
 
   visualization_msgs::MarkerArray convertToDottedLineMarker(const std::vector<geometry_msgs::PoseArray>& path,
                                                       const std::string& frame_id,
@@ -100,8 +100,8 @@ namespace noether_conversions {
                                                       const std::size_t& start_id = 1,
                                                       const std::tuple<float, float, float, float, float, float>& offset = std::make_tuple(
                                                           0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
-                                                      const float& line_width = 0.001,
-                                                      const float& point_size = 0.005);
+                                                      const float& line_width = 0.001f,
+                                                      const float& point_size = 0.005f);
 
 
 }


### PR DESCRIPTION
There was a small build error that appeared when linking against noether_conversions.  Using double literals as default values for float parameters caused very messy build errors.  This may be due to the use PCL 1.10 on Ubuntu 20.04 / ROS Noetic by default.

In order to address this error, the double literals had to be changed to float literals in two functions.  It may be a good idea to crawl through the repository making such adjustments (since it should be triggering warnings anyway during compilation and could create similar errors in the future.