### PR TITLE
Bug fix for plane-slice planner

### DIFF
--- a/tool_path_planner/src/plane_slicer_raster_generator.cpp
+++ b/tool_path_planner/src/plane_slicer_raster_generator.cpp
@@ -469,10 +469,9 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
 
   // computing transformation matrix
   Affine3d t = Translation3d(origin) * AngleAxisd(computeRotation(x_dir, y_dir, z_dir));
-  Affine3d t_inv = t.inverse();
 
   // transforming data
-  vtkSmartPointer<vtkTransform> vtk_transform = toVtkMatrix(t_inv);
+  vtkSmartPointer<vtkTransform> vtk_transform = toVtkMatrix(t);
 
   vtkSmartPointer<vtkTransformFilter> transform_filter = vtkSmartPointer<vtkTransformFilter>::New();
   transform_filter->SetInputData(mesh_data_);
@@ -633,7 +632,7 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
     {
       Vector3d ref_point;
       rasters_data_vec.back().raster_segments.front()->GetPoint(0, ref_point.data());  // first point in previous raster
-      rectifyDirection(raster_lines->GetPoints(), t_inv * ref_point, raster_ids);
+      rectifyDirection(raster_lines->GetPoints(), t * ref_point, raster_ids);
     }
 
     for (auto& rpoint_ids : raster_ids)
@@ -660,7 +659,7 @@ boost::optional<ToolPaths> PlaneSlicerRasterGenerator::generate()
         // transforming to original coordinate system
         transform_filter = vtkSmartPointer<vtkTransformFilter>::New();
         transform_filter->SetInputData(segment_data);
-        transform_filter->SetTransform(toVtkMatrix(t));
+        transform_filter->SetTransform(toVtkMatrix(t.inverse()));
         transform_filter->Update();
         segment_data = transform_filter->GetPolyDataOutput();
 


### PR DESCRIPTION
Breaking out the less controversial content from #116:

The plane slice tool path planner produces incorrect output for a mesh whose centroid is not near its origin. In my test case, the paths are not straight but follow a curved arc. The culprit is the mesh transformation being applied backwards:

https://github.com/ros-industrial/noether/blob/0552f11694f4ee7e3d126d567d1ca81fd35ac01c/tool_path_planner/src/plane_slicer_raster_generator.cpp#L471-L481

### Result before fix:
![Screenshot from 2020-12-10 15-59-13](https://user-images.githubusercontent.com/18411310/101834987-b6edab00-3b00-11eb-81e9-cd6613cc2a7b.png)

### Result after fix:
![Screenshot from 2020-12-10 15-55-31](https://user-images.githubusercontent.com/18411310/101834997-bb19c880-3b00-11eb-9ec6-370451d3cc1c.png)
