### PR TITLE
Bug fix for surface-walk tool path planner

### DIFF
--- a/tool_path_planner/include/tool_path_planner/surface_walk_raster_generator.h
+++ b/tool_path_planner/include/tool_path_planner/surface_walk_raster_generator.h
@@ -79,7 +79,6 @@ public:
     bool generate_extra_rasters{ DEFAULT_GENERATE_EXTRA_RASTERS };
     bool raster_wrt_global_axes{ DEFAULT_RASTER_WRT_GLOBAL_AXIS };
     double cut_direction[3]{ 0, 0, 0 };
-    double cut_centroid[3]{ 0, 0, 0 };
     bool debug{ false };
 
     Json::Value toJson() const

--- a/tool_path_planner/src/surface_walk_raster_generator.cpp
+++ b/tool_path_planner/src/surface_walk_raster_generator.cpp
@@ -1242,7 +1242,7 @@ vtkSmartPointer<vtkPolyData> SurfaceWalkRasterGenerator::createStartCurve()
     Eigen::Vector3d cut_dir(config_.cut_direction);
     if (!cut_dir.isApprox(Eigen::Vector3d::Zero()))
     {
-      max = cut_dir;
+      max = cut_dir.normalized() * max.norm();
     }
     else
     {


### PR DESCRIPTION
I encountered the a bug in the surface-walk tool path planner relating to the specification of the `cut_direction` and `cut_centroid` parameters. The size of the `cut_direction` vector is used to create the initial slice through the mesh. If you set this without regard to the size of your mesh, the first plane cutting the mesh may not fully cross the mesh. The result is tool paths that do not span the entire surface. My solution to this issue is to scale the `cut_direction` vector by the size of the largest OBB axis such that the cutting plane is always wide enough to intersect the entire mesh

This PR also removes the `cut_centroid` parameter. This parameter is unused in the rest of the repository and isn't even defined in the `noether_msgs` surface walk planner config message. Retaining the default value of `[0, 0, 0]` causes issues if the centroid of the mesh is not near `[0, 0, 0]`, like the example below:

![Screenshot from 2020-12-11 09-44-47](https://user-images.githubusercontent.com/18411310/101925119-1d250d00-3b97-11eb-92cf-a08a5e5fb12c.png)

Here the cutting plane (whose size is defined by the extents of the mesh) doesn't even intersect the mesh because it's assumed to be at the defined centroid of `[0, 0, 0]`. Since we already know the centroid of the mesh, why does the user need to specify a centroid if they just want to specify the cut direction? If you do this naively or incorrectly (like how I initially encountered this issue), then the planner fails or only cuts through part of the mesh. My solution is to eliminate the `cut_centroid` parameter and use the already-known centroid of the mesh to generate the cutting plane. The result for my mesh then looks appropriate:

![Screenshot from 2020-12-11 09-40-29](https://user-images.githubusercontent.com/18411310/101929401-662b9000-3b9c-11eb-8cfe-61fd2b8543c2.png) 