### PR TITLE
Raster w.r.t. a specified direction

### DIFF
--- a/noether_msgs/msg/SurfaceWalkRasterGeneratorConfig.msg
+++ b/noether_msgs/msg/SurfaceWalkRasterGeneratorConfig.msg
@@ -5,13 +5,5 @@ float64 intersection_plane_height 	# Used by the raster_tool_path_planner when o
 float64 min_hole_size 			# A path may pass over holes smaller than this, but must be broken when larger holes are encounterd.
 float64 min_segment_size 		# The minimum segment size to allow when finding intersections; small segments will be discarded
 float64 raster_rot_offset               # Specifies the direction of the raster path in radians
-
-# When set to TRUE: initial cuts are determined using the axes of the
-# coordinate frame in which the mesh is placed.  This may cause the
-# initial cut to miss the part.
-# When set to FALSE: initial cuts are determined using the centroid and
-# principal axes of the part.  This is the old default behavior.  (Note
-# that ROS sets message fields to 0/False by default.)
-bool raster_wrt_global_axes
-
 bool generate_extra_rasters   # Whether an extra raster stroke should be added to the beginning and end of the raster pattern
+geometry_msgs/Vector3 cut_direction  # Desired raster direction, in mesh coordinate system (i.e. global coordinate system)

--- a/tool_path_planner/include/tool_path_planner/surface_walk_raster_generator.h
+++ b/tool_path_planner/include/tool_path_planner/surface_walk_raster_generator.h
@@ -64,7 +64,6 @@ class SurfaceWalkRasterGenerator : public PathGenerator
   static constexpr double DEFAULT_INTERSECTION_PLANE_HEIGHT = 0;
   static constexpr double DEFAULT_TOOL_OFFSET = 0;
   static constexpr bool DEFAULT_GENERATE_EXTRA_RASTERS = false;
-  static constexpr bool DEFAULT_RASTER_WRT_GLOBAL_AXIS = false;
 
 public:
   struct Config
@@ -77,7 +76,6 @@ public:
     double intersection_plane_height{ DEFAULT_INTERSECTION_PLANE_HEIGHT };
     double tool_offset{ DEFAULT_TOOL_OFFSET };
     bool generate_extra_rasters{ DEFAULT_GENERATE_EXTRA_RASTERS };
-    bool raster_wrt_global_axes{ DEFAULT_RASTER_WRT_GLOBAL_AXIS };
     double cut_direction[3]{ 0, 0, 0 };
     bool debug{ false };
 

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -152,8 +152,11 @@ bool toSurfaceWalkConfigMsg(noether_msgs::SurfaceWalkRasterGeneratorConfig& conf
   config_msg.min_hole_size = config.min_hole_size;
   config_msg.min_segment_size = config.min_segment_size;
   config_msg.raster_rot_offset = config.raster_rot_offset;
-  config_msg.raster_wrt_global_axes = config.raster_wrt_global_axes;
   config_msg.generate_extra_rasters = config.generate_extra_rasters;
+
+  config_msg.cut_direction.x = config.cut_direction[0];
+  config_msg.cut_direction.y = config.cut_direction[1];
+  config_msg.cut_direction.z = config.cut_direction[2];
   return true;
 }
 
@@ -208,8 +211,12 @@ bool toSurfaceWalkConfig(SurfaceWalkRasterGenerator::Config& config,
   config.min_hole_size = config_msg.min_hole_size;
   config.min_segment_size = config_msg.min_segment_size;
   config.raster_rot_offset = config_msg.raster_rot_offset;
-  config.raster_wrt_global_axes = config_msg.raster_wrt_global_axes;
   config.generate_extra_rasters = config_msg.generate_extra_rasters;
+
+  config.cut_direction[0] = config_msg.cut_direction.x;
+  config.cut_direction[1] = config_msg.cut_direction.y;
+  config.cut_direction[2] = config_msg.cut_direction.z;
+
   return true;
 }
 

--- a/tool_path_planner/test/utest.cpp
+++ b/tool_path_planner/test/utest.cpp
@@ -370,7 +370,6 @@ TEST(IntersectTest, SurfaceWalkRasterRotationTest)
     tool.intersection_plane_height = 0.2;  // 0.5 works best, not sure if this should be included in the tool
     tool.min_hole_size = 0.1;
     tool.raster_rot_offset = direction;
-    tool.raster_wrt_global_axes = false;
     tool.debug = false;
     planner.setConfiguration(tool);
     runRasterRotationTest(planner, mesh);
@@ -393,7 +392,6 @@ TEST(IntersectTest, PlaneSlicerRasterRotationTest)
     //    tool.tool_offset = 0.0;                // currently unused
     tool.min_hole_size = 0.1;
     tool.raster_rot_offset = direction;
-    //    tool.raster_wrt_global_axes = false;
     //    tool.debug = false;
     planner.setConfiguration(tool);
     runRasterRotationTest(planner, mesh);
@@ -532,7 +530,6 @@ TEST(IntersectTest, SurfaceWalkExtraRasterTest)
   tool.intersection_plane_height = 0.2;  // 0.5 works best, not sure if this should be included in the tool
   tool.min_hole_size = 0.1;
   tool.raster_rot_offset = 0.0;
-  tool.raster_wrt_global_axes = false;
   tool.generate_extra_rasters = false;
   tool.debug = false;
 


### PR DESCRIPTION
The current surface walk tool path planner does not properly implement the specification of raster direction with respect to an axis defined in the coordinate system of the mesh. This PR eliminates the `raster_wrt_global_axes_flag` in favor of utilizing the `cut_direction` parameter. If any element of `cut_direction` is non-zero, it will be used as the raster direction. 

Under the hood, the `cut_direction` vector is projected onto the plane defined by the average normal of the mesh. The projected vector then becomes the raster axis, and the average normal becomes the axis about which the raster axis can be rotated by the specified rotation offset.

## Examples
Cut Direction = [-1, 1, 0]
![Screenshot from 2020-12-11 13-05-28](https://user-images.githubusercontent.com/18411310/101944288-1788f080-3bb2-11eb-9e9f-ed89edf347e0.png)

Cut direction = [1, 1, 0]
![Screenshot from 2020-12-11 13-11-01](https://user-images.githubusercontent.com/18411310/101944438-574fd800-3bb2-11eb-92e8-325fd5f5d9cd.png)

Addresses #110 
Merge after #119 