### PR TITLE
Fix bug in tool_path_planner_server.cpp

### DIFF
--- a/noether/src/tool_path_planner_server.cpp
+++ b/noether/src/tool_path_planner_server.cpp
@@ -162,7 +162,7 @@ protected:
           trp.paths.push_back(tp);
         }
 
-	result.tool_paths[i] = trp;
+        result.tool_paths[i] = trp;
         result.tool_path_validities[i] = true;
 
         std::string ros_info_msg = boost::str(boost::format("Surface %1% processed successfully") % (i + 1));

--- a/noether/src/tool_path_planner_server.cpp
+++ b/noether/src/tool_path_planner_server.cpp
@@ -162,6 +162,7 @@ protected:
           trp.paths.push_back(tp);
         }
 
+	result.tool_paths[i] = trp;
         result.tool_path_validities[i] = true;
 
         std::string ros_info_msg = boost::str(boost::format("Surface %1% processed successfully") % (i + 1));


### PR DESCRIPTION
The tool path planner action server currently produces empty tool paths. This is because there is one line missing in the `tool_path_planner_server.cpp` file which copies the local variable (which holds the tool path information) into the action response variable.

I tested this change and it resolved the issue. 