### PR TITLE
Refactor: tool path organization modifiers

### DIFF
--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(${PROJECT_NAME} SHARED
   # Tool Path Modifiers
   src/tool_path_modifiers/compound_modifier.cpp
   src/tool_path_modifiers/waypoint_orientation_modifiers.cpp
+  src/tool_path_modifiers/organization_modifiers.cpp
   # Tool Path Planners
   src/tool_path_planners/edge_planner.cpp
   src/tool_path_planners/raster_planner.cpp

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <noether_tpp/core/tool_path_modifier.h>
+
+namespace noether
+{
+/**
+ * @brief Organizes a tool path into a raster-style pattern
+ * @details The tool path is organized with the following structure:
+ *   - waypoints are sorted within each tool path segment in ascending order by x-axis value
+ *   - tool path segments are sorted within each tool path in ascending order by the x-axis value of their first
+ * waypoint
+ *   - tool paths are sorted in ascending order by the y-axis value of the first waypoint in the first tool path segment
+ */
+struct RasterOrganizationModifier : OneTimeToolPathModifier
+{
+  using OneTimeToolPathModifier::OneTimeToolPathModifier;
+
+  ToolPaths modify(ToolPaths) const override;
+};
+
+/**
+ * @brief Organizes a tool path into a snake-style pattern
+ * @details The tool path is organized with the following structure:
+ *   - Tool paths at even indices are sorted by ascending waypoint x-axis value; segments in the tool path are also
+ * sorted by ascending x-axis value of their first waypoint
+ *   - Tool paths at odd indices are sorted by descending waypoint x-axis value; segments in the tool path are also
+ * sorted by descending x-axis value of their first waypoint
+ *   - Tool paths are sorted relative to one another by ascending y-axis value of the first waypoint in the first tool
+ * path segment
+ */
+struct SnakeOrganizationModifier : OneTimeToolPathModifier
+{
+  using OneTimeToolPathModifier::OneTimeToolPathModifier;
+
+  ToolPaths modify(ToolPaths) const override;
+};
+
+}  // namespace noether

--- a/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
+++ b/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
@@ -1,0 +1,60 @@
+#include <noether_tpp/tool_path_modifiers/organization_modifiers.h>
+
+namespace noether
+{
+ToolPaths RasterOrganizationModifier::modify(ToolPaths tool_paths) const
+{
+  for (ToolPath& tool_path : tool_paths)
+  {
+    // Sort waypoints in each tool path segment by ascending x-axis value (i.e. left to right)
+    for (ToolPathSegment& segment : tool_path)
+    {
+      std::sort(segment.begin(), segment.end(), [](const ToolPathWaypoint& a, const ToolPathWaypoint& b) {
+        return a.translation().x() < b.translation().x();
+      });
+    }
+
+    // Sort the tool path segments by ascending x-axis value of the first waypoint in each tool path segment
+    std::sort(tool_path.begin(), tool_path.end(), [](const ToolPathSegment& a, const ToolPathSegment& b) {
+      return a.at(0).translation().x() < b.at(0).translation().x();
+    });
+  }
+
+  // Sort the tool paths by ascending y-axis value of the first waypoint in the first tool path segment of each tool
+  // path
+  std::sort(tool_paths.begin(), tool_paths.end(), [](const ToolPath& a, const ToolPath& b) {
+    return a.at(0).at(0).translation().y() < b.at(0).at(0).translation().y();
+  });
+
+  return tool_paths;
+}
+
+ToolPaths SnakeOrganizationModifier::modify(ToolPaths tool_paths) const
+{
+  // Create a raster
+  RasterOrganizationModifier raster;
+  tool_paths = raster.modify(tool_paths);
+
+  // Re-sort the tool paths at odd indices
+  for (std::size_t i = 1; i < tool_paths.size(); i += 2)
+  {
+    ToolPath& tool_path = tool_paths.at(i);
+
+    // Sort waypoints in each tool path segment by descending x-axis value (i.e. right to left)
+    for (ToolPathSegment& segment : tool_path)
+    {
+      std::sort(segment.begin(), segment.end(), [](const ToolPathWaypoint& a, const ToolPathWaypoint& b) {
+        return a.translation().x() > b.translation().x();
+      });
+    }
+
+    // Sort the tool path segments by descending x-axis value of the first waypoint in each tool path segment
+    std::sort(tool_path.begin(), tool_path.end(), [](const ToolPathSegment& a, const ToolPathSegment& b) {
+      return a.at(0).translation().x() > b.at(0).translation().x();
+    });
+  }
+
+  return tool_paths;
+}
+
+}  // namespace noether


### PR DESCRIPTION
This PR adds tool path modifiers that change the way that tool paths are organized for raster and snake-style tool paths
