### PR TITLE
Refactor: Tool Path Modifiers for Standard Raster and Edge Path Planner Configuration

### DIFF
--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
@@ -6,11 +6,9 @@ namespace noether
 {
 /**
  * @brief Organizes a tool path into a raster-style pattern
- * @details The tool path is organized with the following structure:
- *   - waypoints are sorted within each tool path segment in ascending order by x-axis value
- *   - tool path segments are sorted within each tool path in ascending order by the x-axis value of their first
- * waypoint
- *   - tool paths are sorted in ascending order by the y-axis value of the first waypoint in the first tool path segment
+ * @details  Waypoints are sorted within each tool path segment in ascending order by x-axis value. Tool path segments
+ * are sorted within each tool path in ascending order by the x-axis value of their first waypoint. Tool paths are
+ * sorted in ascending order by the y-axis value of the first waypoint in the first tool path segment.
  */
 struct RasterOrganizationModifier : OneTimeToolPathModifier
 {
@@ -21,13 +19,8 @@ struct RasterOrganizationModifier : OneTimeToolPathModifier
 
 /**
  * @brief Organizes a tool path into a snake-style pattern
- * @details The tool path is organized with the following structure:
- *   - Tool paths at even indices are sorted by ascending waypoint x-axis value; segments in the tool path are also
- * sorted by ascending x-axis value of their first waypoint
- *   - Tool paths at odd indices are sorted by descending waypoint x-axis value; segments in the tool path are also
- * sorted by descending x-axis value of their first waypoint
- *   - Tool paths are sorted relative to one another by ascending y-axis value of the first waypoint in the first tool
- * path segment
+ * @details A RasterOrganizationModifier is first used to organize the tool paths into a raster pattern. The tool paths
+ * at odd indices are then reversed to produce the snake pattern.
  */
 struct SnakeOrganizationModifier : OneTimeToolPathModifier
 {

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
@@ -29,4 +29,23 @@ struct SnakeOrganizationModifier : OneTimeToolPathModifier
   ToolPaths modify(ToolPaths) const override;
 };
 
+/**
+ * @brief Organizes a set of tool paths into a standard configuration for edge paths
+ * @details Waypoints are sorted within each tool path segment in ascending order along the average x-axis direction of
+ * the waypoints in the segment. Segments are ordered in a tool path such that the start of one segment is as close as
+ * possible to the end of the previous segment. The first segment is chosen as the one whose first waypoint is closest
+ * to a reference position. Tool path segments are ordered in the top-level container in order of length, from longest
+ * to shortest
+ */
+class StandardEdgePathsOrganizationModifier : public OneTimeToolPathModifier
+{
+public:
+  StandardEdgePathsOrganizationModifier(const Eigen::Vector3d& start_reference = Eigen::Vector3d::Zero());
+
+  ToolPaths modify(ToolPaths) const override;
+
+private:
+  const Eigen::Vector3d start_reference_;
+};
+
 }  // namespace noether

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/organization_modifiers.h
@@ -31,11 +31,10 @@ struct SnakeOrganizationModifier : OneTimeToolPathModifier
 
 /**
  * @brief Organizes a set of tool paths into a standard configuration for edge paths
- * @details Waypoints are sorted within each tool path segment in ascending order along the average x-axis direction of
- * the waypoints in the segment. Segments are ordered in a tool path such that the start of one segment is as close as
+ * @details Segments are ordered in a tool path such that the start of one segment is as close as
  * possible to the end of the previous segment. The first segment is chosen as the one whose first waypoint is closest
  * to a reference position. Tool path segments are ordered in the top-level container in order of length, from longest
- * to shortest
+ * to shortest. Note: waypoints are expected to be ordered correctly on input to the modifier
  */
 class StandardEdgePathsOrganizationModifier : public OneTimeToolPathModifier
 {

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/waypoint_orientation_modifiers.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/waypoint_orientation_modifiers.h
@@ -24,7 +24,7 @@ protected:
 };
 
 /**
- * @brief Aligns the x-axis of all waypoints with the direction of travel of the first two waypoints.
+ * @brief Aligns the x-axis of all waypoints with the direction of travel between adjacent waypoints
  */
 struct DirectionOfTravelOrientationModifier : public OneTimeToolPathModifier
 {
@@ -32,7 +32,7 @@ struct DirectionOfTravelOrientationModifier : public OneTimeToolPathModifier
 };
 
 /**
- * @brief Aligns the x-axis of all waypoints with the direction of travel of the first two waypoints.
+ * @brief Aligns the x-axis of all waypoints with the direction of travel of the first two waypoints
  * @details Re-alignment of the waypoint orientation only occurs if the dot product of the waypoint x-axis and the
  * reference direction of travel is less than zero. In the case of an orientation change, the waypoint is simply rotated
  * about its z-axis by 180 degrees

--- a/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
+++ b/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
@@ -180,16 +180,6 @@ static ToolPaths sortToolPathsByLength(const ToolPaths& tool_paths)
   return reorder(tool_paths, order);
 }
 
-static Eigen::Vector3d getAverageXAxis(const ToolPathSegment& segment)
-{
-  Eigen::Vector3d mean = Eigen::Vector3d::Zero();
-  for (const ToolPathWaypoint& w : segment)
-  {
-    mean += w.matrix().col(0).head<3>();
-  }
-  return mean / static_cast<double>(segment.size());
-}
-
 StandardEdgePathsOrganizationModifier::StandardEdgePathsOrganizationModifier(const Eigen::Vector3d& start_reference)
   : start_reference_(start_reference)
 {
@@ -197,21 +187,6 @@ StandardEdgePathsOrganizationModifier::StandardEdgePathsOrganizationModifier(con
 
 ToolPaths StandardEdgePathsOrganizationModifier::modify(ToolPaths tool_paths) const
 {
-  // Sort the waypoints in each tool path segment
-  for (ToolPath& path : tool_paths)
-  {
-    for (ToolPathSegment& segment : path)
-    {
-      // Get the nominal direction of this segment by averaging all the waypoints' x-axes
-      const Eigen::Vector3d ref_dir = getAverageXAxis(segment);
-
-      // Project the position of the waypoints onto the reference direction vector to order them from start to end
-      std::sort(segment.begin(), segment.end(), [&ref_dir](const ToolPathWaypoint& a, const ToolPathWaypoint& b) {
-        return a.translation().dot(ref_dir) < b.translation().dot(ref_dir);
-      });
-    }
-  }
-
   // Sort the tool path segments such that the first segment is the one whose first waypoint is nearest the start
   // reference point and subsequent segments start near the end of the previous segment
   ToolPaths ordered_tool_paths;

--- a/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
+++ b/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
@@ -85,7 +85,9 @@ static std::vector<std::size_t> sortToolPathBySegmentConnection(const ToolPath& 
     std::vector<std::size_t> remaining_segment_indices;
     {
       std::vector<std::size_t> order(path.size());
+      // Fill the order vector with increasing integers, starting at 0
       std::iota(order.begin(), order.end(), 0);
+      // Extract only the indices that have not been used so far into remaining_segment_indices
       std::set_difference(order.begin(),
                           order.end(),
                           segment_order.begin(),

--- a/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
+++ b/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
@@ -1,5 +1,7 @@
 #include <noether_tpp/tool_path_modifiers/organization_modifiers.h>
 
+#include <numeric>
+
 namespace noether
 {
 ToolPaths RasterOrganizationModifier::modify(ToolPaths tool_paths) const
@@ -55,6 +57,177 @@ ToolPaths SnakeOrganizationModifier::modify(ToolPaths tool_paths) const
   }
 
   return tool_paths;
+}
+
+/**
+ * @brief Organizes the tool path segments within each tool path in the container such that the beginning of a tool path
+ * is as close as possible to the end of the previous tool path (or a reference position, in the case of the first tool
+ * path)
+ * @details The primary intent of this function is to organize tool path segments for edge tool paths; these segments
+ * represent segments of an edge and should be arranged in a sequential and connected order.
+ */
+static std::vector<std::size_t> sortToolPathBySegmentConnection(const ToolPath& path,
+                                                                const Eigen::Vector3d& start_reference)
+{
+  std::vector<std::size_t> segment_order;
+  segment_order.reserve(path.size());
+
+  // Comparator function for finding the segment whose first waypoint is closest to the reference position
+  auto compare_distances = [&path](const std::size_t& a, const std::size_t& b, const Eigen::Vector3d& ref) {
+    double d_a = (path.at(a).at(0).translation() - ref).norm();
+    double d_b = (path.at(b).at(0).translation() - ref).norm();
+    return d_a < d_b;
+  };
+
+  while (segment_order.size() < path.size())
+  {
+    // Get the indices of the yet unordered segments
+    std::vector<std::size_t> remaining_segment_indices;
+    {
+      std::vector<std::size_t> order(path.size());
+      std::iota(order.begin(), order.end(), 0);
+      std::set_difference(order.begin(),
+                          order.end(),
+                          segment_order.begin(),
+                          segment_order.end(),
+                          std::back_inserter(remaining_segment_indices));
+    }
+
+    if (remaining_segment_indices.size() == 1)
+    {
+      segment_order.push_back(remaining_segment_indices.front());
+    }
+    else
+    {
+      // Get the reference point with which to compare the segment start positions
+      Eigen::Vector3d ref;
+      if (segment_order.empty())
+      {
+        // Use the reference start position if no segments have been ordered yet
+        ref = start_reference;
+      }
+      else
+      {
+        // Otherwise use the position of the last waypoint in the last ordered segment
+        ref = path.at(segment_order.back()).back().translation();
+      }
+
+      // Find the segment whose first waypoint is closest to the reference position
+      auto comp = std::bind(compare_distances, std::placeholders::_1, std::placeholders::_2, ref);
+      std::sort(remaining_segment_indices.begin(), remaining_segment_indices.end(), comp);
+
+      // Add the index of that segment to the output variable
+      segment_order.push_back(remaining_segment_indices.front());
+    }
+  }
+
+  return segment_order;
+}
+
+/**
+ * @brief Helper function for creating a re-ordered copy of a vector
+ */
+template <typename T>
+static std::vector<T> reorder(const std::vector<T>& input, const std::vector<std::size_t>& order)
+{
+  std::vector<T> output;
+  output.reserve(input.size());
+
+  for (std::size_t idx : order)
+  {
+    output.push_back(input.at(idx));
+  }
+
+  return output;
+}
+
+/**
+ * @brief Organizes the container of tool paths according to the length of all the tool path segments in the tool path
+ * @details The tool paths are sorted from longest to shortest. The organization of the tool path segments within each
+ * tool path and the waypoints within each tool path segment are not changed. The primary intent of this modifier is for
+ * sorting edge tool paths by length.
+ */
+static ToolPaths sortToolPathsByLength(const ToolPaths& tool_paths)
+{
+  std::vector<double> path_lengths;
+  path_lengths.reserve(tool_paths.size());
+
+  for (const ToolPath& path : tool_paths)
+  {
+    double path_length = 0.0;
+
+    for (const ToolPathSegment& segment : path)
+    {
+      for (std::size_t i = 0; i < segment.size() - 1; ++i)
+      {
+        const ToolPathWaypoint& first = segment.at(i);
+        const ToolPathWaypoint& second = segment.at(i + 1);
+        path_length += (first.inverse() * second).translation().norm();
+      }
+    }
+
+    path_lengths.push_back(path_length);
+  }
+
+  // Argsort the path lengths from largest to shortest
+  std::vector<std::size_t> order(path_lengths.size());
+  std::iota(order.begin(), order.end(), 0);
+  std::sort(order.begin(), order.end(), [&path_lengths](const std::size_t& a, const std::size_t& b) {
+    return path_lengths.at(a) > path_lengths.at(b);
+  });
+
+  // Copy the tool paths in the new order
+  return reorder(tool_paths, order);
+}
+
+static Eigen::Vector3d getAverageXAxis(const ToolPathSegment& segment)
+{
+  Eigen::Vector3d mean = Eigen::Vector3d::Zero();
+  for (const ToolPathWaypoint& w : segment)
+  {
+    mean += w.matrix().col(0).head<3>();
+  }
+  return mean / static_cast<double>(segment.size());
+}
+
+StandardEdgePathsOrganizationModifier::StandardEdgePathsOrganizationModifier(const Eigen::Vector3d& start_reference)
+  : start_reference_(start_reference)
+{
+}
+
+ToolPaths StandardEdgePathsOrganizationModifier::modify(ToolPaths tool_paths) const
+{
+  // Sort the waypoints in each tool path segment
+  for (ToolPath& path : tool_paths)
+  {
+    for (ToolPathSegment& segment : path)
+    {
+      // Get the nominal direction of this segment by averaging all the waypoints' x-axes
+      const Eigen::Vector3d ref_dir = getAverageXAxis(segment);
+
+      // Project the position of the waypoints onto the reference direction vector to order them from start to end
+      std::sort(segment.begin(), segment.end(), [&ref_dir](const ToolPathWaypoint& a, const ToolPathWaypoint& b) {
+        return a.translation().dot(ref_dir) < b.translation().dot(ref_dir);
+      });
+    }
+  }
+
+  // Sort the tool path segments such that the first segment is the one whose first waypoint is nearest the start
+  // reference point and subsequent segments start near the end of the previous segment
+  ToolPaths ordered_tool_paths;
+  ordered_tool_paths.reserve(tool_paths.size());
+
+  for (ToolPath& path : tool_paths)
+  {
+    // Get the desired order of the tool path segments
+    std::vector<std::size_t> segment_order = sortToolPathBySegmentConnection(path, start_reference_);
+
+    // Create a new tool path with the segments in the desired order
+    ordered_tool_paths.push_back(reorder(path, segment_order));
+  }
+
+  // Sort the tool paths by length
+  return sortToolPathsByLength(ordered_tool_paths);
 }
 
 }  // namespace noether

--- a/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
+++ b/noether_tpp/src/tool_path_modifiers/organization_modifiers.cpp
@@ -72,13 +72,6 @@ static std::vector<std::size_t> sortToolPathBySegmentConnection(const ToolPath& 
   std::vector<std::size_t> segment_order;
   segment_order.reserve(path.size());
 
-  // Comparator function for finding the segment whose first waypoint is closest to the reference position
-  auto compare_distances = [&path](const std::size_t& a, const std::size_t& b, const Eigen::Vector3d& ref) {
-    double d_a = (path.at(a).at(0).translation() - ref).norm();
-    double d_b = (path.at(b).at(0).translation() - ref).norm();
-    return d_a < d_b;
-  };
-
   while (segment_order.size() < path.size())
   {
     // Get the indices of the yet unordered segments
@@ -115,11 +108,20 @@ static std::vector<std::size_t> sortToolPathBySegmentConnection(const ToolPath& 
       }
 
       // Find the segment whose first waypoint is closest to the reference position
-      auto comp = std::bind(compare_distances, std::placeholders::_1, std::placeholders::_2, ref);
-      std::sort(remaining_segment_indices.begin(), remaining_segment_indices.end(), comp);
+      double min_dist = std::numeric_limits<double>::max();
+      std::size_t min_index = 0;
+      for (std::size_t idx : remaining_segment_indices)
+      {
+        double dist = (path.at(idx).at(0).translation() - ref).norm();
+        if (dist < min_dist)
+        {
+          min_dist = dist;
+          min_index = idx;
+        }
+      }
 
       // Add the index of that segment to the output variable
-      segment_order.push_back(remaining_segment_indices.front());
+      segment_order.push_back(min_index);
     }
   }
 

--- a/noether_tpp/src/tool_path_planners/edge_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/edge_planner.cpp
@@ -2,13 +2,25 @@
 
 #include <utility>  // std::move()
 
+#include <noether_tpp/tool_path_modifiers/organization_modifiers.h>
+#include <noether_tpp/tool_path_modifiers/waypoint_orientation_modifiers.h>
+
 namespace noether
 {
 ToolPaths EdgePlanner::plan(const pcl::PolygonMesh& mesh) const
 {
   ToolPaths tool_paths = planImpl(mesh);
 
-  // To-do: implement the modifications necessary to produce the default behavior
+  // Apply the modifications necessary to produce the "default" behavior
+  // First, organize the position of the waypoints into standard edge paths
+  StandardEdgePathsOrganizationModifier edge_path_organizer;
+  tool_paths = edge_path_organizer.modify(tool_paths);
+
+  // Next, update the orientation of the waypoints such that their x-axes align with the direction of travel between
+  // adjacent waypoints. Note: this modifier does not change the z-axis of the waypoints (normal to the surface)
+  // returned by the planner implementation
+  DirectionOfTravelOrientationModifier dot_orientation;
+  tool_paths = dot_orientation.modify(tool_paths);
 
   return tool_paths;
 }

--- a/noether_tpp/src/tool_path_planners/raster_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/raster_planner.cpp
@@ -2,6 +2,9 @@
 
 #include <utility>  // std::move()
 
+#include <noether_tpp/tool_path_modifiers/organization_modifiers.h>
+#include <noether_tpp/tool_path_modifiers/waypoint_orientation_modifiers.h>
+
 namespace noether
 {
 RasterPlanner::RasterPlanner(std::unique_ptr<DirectionGenerator> dir_gen, std::unique_ptr<OriginGenerator> origin_gen)
@@ -11,9 +14,19 @@ RasterPlanner::RasterPlanner(std::unique_ptr<DirectionGenerator> dir_gen, std::u
 
 ToolPaths RasterPlanner::plan(const pcl::PolygonMesh& mesh) const
 {
+  // Call the raster planner implementation
   ToolPaths tool_paths = planImpl(mesh);
 
-  // To-do: implement the modifications necessary to produce the default behavior
+  // Apply the modifications necessary to produce the "default" behavior
+  // First, organize the position of the waypoints into a raster pattern
+  RasterOrganizationModifier raster;
+  tool_paths = raster.modify(tool_paths);
+
+  // Next, update the orientation of the waypoints such that their x-axes align with the direction of travel between
+  // adjacent waypoints. Note: this modifier does not change the z-axis of the waypoints (normal to the surface)
+  // returned by the planner implementation
+  DirectionOfTravelOrientationModifier dot_orientation;
+  tool_paths = dot_orientation.modify(tool_paths);
 
   return tool_paths;
 }

--- a/noether_tpp/test/tool_path_modifier_utest.cpp
+++ b/noether_tpp/test/tool_path_modifier_utest.cpp
@@ -119,17 +119,20 @@ ToolPaths createSquareToolPaths(const unsigned p, const unsigned w)
   return paths;
 }
 
-ToolPaths shuffle(ToolPaths tool_paths, std::size_t seed = 0)
+ToolPaths shuffle(ToolPaths tool_paths, const bool shuffle_waypoints, const std::size_t seed = 0)
 {
   // Seeded random number generator
   std::mt19937 rand(seed);
 
   for (ToolPath& tool_path : tool_paths)
   {
-    for (ToolPathSegment& segment : tool_path)
+    if (shuffle_waypoints)
     {
-      // Shuffle the order of waypoints in tool path segments
-      std::shuffle(segment.begin(), segment.end(), rand);
+      for (ToolPathSegment& segment : tool_path)
+      {
+        // Shuffle the order of waypoints in tool path segments
+        std::shuffle(segment.begin(), segment.end(), rand);
+      }
     }
 
     // Shuffle the order of tool path segments in the tool path
@@ -274,7 +277,7 @@ TEST(ToolPathModifierTests, OrganizationModifiersTest)
   const unsigned n_segments = 2;
   const unsigned n_waypoints = 10;
   const ToolPaths tool_paths = createRasterGridToolPath(n_paths, n_segments, n_waypoints);
-  const ToolPaths shuffled_tool_paths = shuffle(tool_paths);
+  const ToolPaths shuffled_tool_paths = shuffle(tool_paths, true);
 
   // Create a raster pattern from the original tool paths
   RasterOrganizationModifier raster;
@@ -321,7 +324,9 @@ TEST(ToolPathModifierTests, EdgePathOrganizationModifiersTest)
   compare(edge_path_organizer.modify(tool_paths), tool_paths);
 
   // Shuffle the tool paths and re-sort them into an ordered set of edge paths
-  ToolPaths edge_tool_paths = edge_path_organizer.modify(shuffle(tool_paths));
+  // Note: the standard edge path organization modifier expects the planner to have provided the waypoints in the
+  // correct order, so don't shuffle them within the segments/tool paths
+  ToolPaths edge_tool_paths = edge_path_organizer.modify(shuffle(tool_paths, false));
 
   // Check for equivalence with the original tool path
   compare(edge_tool_paths, tool_paths);


### PR DESCRIPTION
This PR:
- Implements the tool path modifiers to produce the standard raster path configuration in the raster planner class
- Adds a tool path modifier for organizing edge path plans into the desired configuration
- Implements the tool path modifiers to produce the standard edge path configuration in the edge planner class