### PR TITLE
noether_filtering CMakeLists Update

### DIFF
--- a/noether_filtering/CMakeLists.txt
+++ b/noether_filtering/CMakeLists.txt
@@ -159,4 +159,8 @@ if(${ENABLE_TESTS})
 endif()
 
 # Configure package
-configure_package(NAMESPACE noether TARGETS ${PACKAGE_LIBRARIES})
+configure_package(
+  NAMESPACE noether
+  TARGETS ${PACKAGE_LIBRARIES}
+  DEPENDENCIES "PCL REQUIRED COMPONENTS common filters surface segmentation" VTK pluginlib console_bridge xmlrpcpp
+)


### PR DESCRIPTION
This PR updates the `noether_filtering` CMakeLists to export its `find_package` dependencies correctly