### PR TITLE
Fix normals in plane_slicer_raster_planner.cpp

### DIFF
--- a/noether_msgs/msg/PlaneSlicerRasterGeneratorConfig.msg
+++ b/noether_msgs/msg/PlaneSlicerRasterGeneratorConfig.msg
@@ -4,3 +4,4 @@ float64 raster_rot_offset  # Specifies the direction of the raster path in radia
 float64 min_segment_size   # The minimum segment size to allow when finding intersections; small segments will be discarded
 float64 min_hole_size 	   # A path may pass over holes smaller than this, but must be broken when larger holes are encounterd.
 float64 tool_offset 	   # How far off the surface the tool needs to be
+float64 search_radius 	   # Radius to average normals, set equal or lower to zero to not average normals.

--- a/noether_tpp/src/tool_path_planners/plane_slicer_raster_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/plane_slicer_raster_planner.cpp
@@ -316,7 +316,7 @@ noether::ToolPaths convertToPoses(const std::vector<RasterConstructData>& raster
         polydata->GetPointData()->GetNormals()->GetTuple(idx, vz.data());
         vx = (p_next - p).normalized();
         vy = vz.cross(vx).normalized();
-        vz = vx.cross(vy).normalized();
+        vx = vy.cross(vz).normalized();
         pose = Eigen::Translation3d(p) * Eigen::AngleAxisd(computeRotation(vx, vy, vz));
         raster_path_segment.push_back(pose);
       }

--- a/tool_path_planner/src/utilities.cpp
+++ b/tool_path_planner/src/utilities.cpp
@@ -169,6 +169,7 @@ bool toPlaneSlicerConfigMsg(noether_msgs::PlaneSlicerRasterGeneratorConfig& conf
   config_msg.min_hole_size = config.min_hole_size;
   config_msg.min_segment_size = config.min_segment_size;
   config_msg.raster_rot_offset = config.raster_rot_offset;
+  config_msg.search_radius = config.search_radius;
 
   return true;
 }
@@ -229,6 +230,7 @@ bool toPlaneSlicerConfig(PlaneSlicerRasterGenerator::Config& config,
   config.min_hole_size = config_msg.min_hole_size;
   config.min_segment_size = config_msg.min_segment_size;
   config.raster_rot_offset = config_msg.raster_rot_offset;
+  config.search_radius = config_msg.search_radius;
 
   return true;
 }


### PR DESCRIPTION
Fix issue #179 with normals. The changed line was previously changing the normals according to vx, I used something similar to what is used in the waypoint_orientation_modifiers: https://github.com/ros-industrial/noether/blob/e0b5b17c08e545bff471d9878ba43b3bd25ae27b/noether_tpp/src/tool_path_modifiers/waypoint_orientation_modifiers.cpp#L25