### PR TITLE
Add YAML Configuration for TPP GUI

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(boost_plugin_loader REQUIRED)
 find_package(noether_tpp REQUIRED)
 find_package(PCL REQUIRED COMPONENTS io surface)
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
+find_package(yaml-cpp REQUIRED)
 
 option(NOETHER_ENABLE_CLANG_TIDY "Enables compilation with clang-tidy" OFF)
 option(NOETHER_ENABLE_TESTING "Enables compilation of unit tests" OFF)
@@ -54,7 +55,7 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
-target_link_libraries(${PROJECT_NAME} PUBLIC noether::noether_tpp Qt5::Widgets ${PCL_LIBRARIES} boost_plugin_loader::boost_plugin_loader Eigen3::Eigen)
+target_link_libraries(${PROJECT_NAME} PUBLIC noether::noether_tpp Qt5::Widgets ${PCL_LIBRARIES} boost_plugin_loader::boost_plugin_loader Eigen3::Eigen yaml-cpp)
 target_compile_definitions(${PROJECT_NAME} PUBLIC NOETHER_GUI_PLUGINS="${PROJECT_NAME}_plugins")
 target_cxx_version(${PROJECT_NAME} PUBLIC VERSION 14)
 target_clang_tidy(${PROJECT_NAME}

--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -56,7 +56,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 target_link_libraries(${PROJECT_NAME} PUBLIC noether::noether_tpp Qt5::Widgets ${PCL_LIBRARIES} boost_plugin_loader::boost_plugin_loader Eigen3::Eigen yaml-cpp)
-target_compile_definitions(${PROJECT_NAME} PUBLIC NOETHER_GUI_PLUGINS="${PROJECT_NAME}_plugins")
+target_compile_definitions(${PROJECT_NAME}
+  PUBLIC
+    NOETHER_GUI_PLUGINS="${PROJECT_NAME}_plugins"
+    NOETHER_GUI_TPP_SECTION="tpp"
+    NOETHER_GUI_DIRECTION_GENERATOR_SECTION="dg"
+    NOETHER_GUI_ORIGIN_GENERATOR_SECTION="og"
+    NOETHER_GUI_TOOL_PATH_MODIFIER_SECTION="mod"
+    NOETHER_GUI_MESH_MODIFIER_SECTION="mesh"
+)
 target_cxx_version(${PROJECT_NAME} PUBLIC VERSION 14)
 target_clang_tidy(${PROJECT_NAME}
   ENABLE ${NOETHER_ENABLE_CLANG_TIDY}

--- a/noether_gui/include/noether_gui/plugin_interface.h
+++ b/noether_gui/include/noether_gui/plugin_interface.h
@@ -24,6 +24,7 @@ template <typename T>
 class WidgetPlugin
 {
 public:
+  using WidgetT = T;
   using Ptr = std::shared_ptr<WidgetPlugin>;
   virtual ~WidgetPlugin() = default;
 

--- a/noether_gui/include/noether_gui/plugin_interface.h
+++ b/noether_gui/include/noether_gui/plugin_interface.h
@@ -3,6 +3,7 @@
 #include <noether_gui/widgets.h>
 #include <string>
 #include <memory>
+#include <yaml-cpp/yaml.h>
 
 class QWidget;
 
@@ -26,7 +27,7 @@ public:
   using Ptr = std::shared_ptr<WidgetPlugin>;
   virtual ~WidgetPlugin() = default;
 
-  virtual QWidget* create(QWidget* parent = nullptr) const = 0;
+  virtual QWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const = 0;
 
 private:
   friend class boost_plugin_loader::PluginLoader;

--- a/noether_gui/include/noether_gui/utils.h
+++ b/noether_gui/include/noether_gui/utils.h
@@ -63,4 +63,20 @@ T getEntry(const YAML::Node& config, const std::string& key)
   }
 }
 
+/**
+ * @details Adapted from https://en.cppreference.com/w/cpp/error/throw_with_nested
+ */
+inline void printException(const std::exception& e, std::ostream& ss, int level = 0)
+{
+  ss << std::string(level * 4, ' ') << e.what() << '\n';
+  try
+  {
+    std::rethrow_if_nested(e);
+  }
+  catch (const std::exception& nested_exception)
+  {
+    printException(nested_exception, ss, level + 1);
+  }
+}
+
 }  // namespace noether

--- a/noether_gui/include/noether_gui/utils.h
+++ b/noether_gui/include/noether_gui/utils.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <boost_plugin_loader/plugin_loader.h>
+#include <boost/core/demangle.hpp>
 #include <QLayoutItem>
 #include <QLayout>
 #include <QStringList>
 #include <QWidget>
 #include <string>
 #include <vector>
+#include <yaml-cpp/node/node.h>
+#include <yaml-cpp/exceptions.h>
 
 namespace noether
 {
@@ -46,6 +49,21 @@ inline void overwriteWidget(QLayout* layout, QWidget*& from, QWidget* to)
   // reference
   delete from;
   from = to;
+}
+
+template <typename T>
+T getEntry(const YAML::Node& config, const std::string& key)
+{
+  try
+  {
+    return config[key].as<T>();
+  }
+  catch (const YAML::Exception&)
+  {
+    std::stringstream ss;
+    ss << "Failed to cast parameter '" << key << "' as type '" << boost::core::demangle(typeid(T).name()) << "'";
+    throw std::runtime_error(ss.str());
+  }
 }
 
 }  // namespace noether

--- a/noether_gui/include/noether_gui/utils.h
+++ b/noether_gui/include/noether_gui/utils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <boost_plugin_loader/plugin_loader.h>
-#include <boost/core/demangle.hpp>
 #include <QLayoutItem>
 #include <QLayout>
 #include <QStringList>
@@ -60,9 +59,7 @@ T getEntry(const YAML::Node& config, const std::string& key)
   }
   catch (const YAML::Exception&)
   {
-    std::stringstream ss;
-    ss << "Failed to cast parameter '" << key << "' as type '" << boost::core::demangle(typeid(T).name()) << "'";
-    throw std::runtime_error(ss.str());
+    throw std::runtime_error("Failed to load parameter '" + key + "'");
   }
 }
 

--- a/noether_gui/include/noether_gui/widgets.h
+++ b/noether_gui/include/noether_gui/widgets.h
@@ -27,6 +27,7 @@ public:
   virtual typename T::ConstPtr create() const = 0;
 
   virtual void configure(const YAML::Node&) {}
+  virtual void save(YAML::Node&) const {}
 };
 
 using ToolPathPlannerWidget = BaseWidget<ToolPathPlanner>;

--- a/noether_gui/include/noether_gui/widgets.h
+++ b/noether_gui/include/noether_gui/widgets.h
@@ -2,6 +2,11 @@
 
 #include <QWidget>
 
+namespace YAML
+{
+class Node;
+}
+
 namespace noether
 {
 class ToolPathPlanner;
@@ -20,6 +25,8 @@ public:
   BaseWidget(QWidget* parent = nullptr) : QWidget(parent) {}
 
   virtual typename T::ConstPtr create() const = 0;
+
+  virtual void fromYAML(const YAML::Node&) {}
 };
 
 using ToolPathPlannerWidget = BaseWidget<ToolPathPlanner>;

--- a/noether_gui/include/noether_gui/widgets.h
+++ b/noether_gui/include/noether_gui/widgets.h
@@ -26,7 +26,7 @@ public:
 
   virtual typename T::ConstPtr create() const = 0;
 
-  virtual void fromYAML(const YAML::Node&) {}
+  virtual void configure(const YAML::Node&) {}
 };
 
 using ToolPathPlannerWidget = BaseWidget<ToolPathPlanner>;

--- a/noether_gui/include/noether_gui/widgets/blending_tool_path_modifier_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/blending_tool_path_modifier_widgets.h
@@ -47,7 +47,7 @@ public:
 private:
   QDoubleSpinBox* arc_angle_;
   QDoubleSpinBox* arc_radius_;
-  QSpinBox* n_points;
+  QSpinBox* n_points_;
 };
 
 }  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/blending_tool_path_modifier_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/blending_tool_path_modifier_widgets.h
@@ -17,6 +17,9 @@ public:
 
   ToolPathModifier::ConstPtr create() const override;
 
+  void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
+
 private:
   QDoubleSpinBox* angle_offset_;
   QDoubleSpinBox* tool_radius_;
@@ -29,6 +32,9 @@ public:
   CircularLeadInToolPathModifierWidget(QWidget* parent = nullptr);
 
   ToolPathModifier::ConstPtr create() const override;
+
+  void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
 
 private:
   QDoubleSpinBox* arc_angle_;
@@ -43,6 +49,9 @@ public:
   CircularLeadOutToolPathModifierWidget(QWidget* parent = nullptr);
 
   ToolPathModifier::ConstPtr create() const override;
+
+  void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
 
 private:
   QDoubleSpinBox* arc_angle_;

--- a/noether_gui/include/noether_gui/widgets/collapsible_area_widget.h
+++ b/noether_gui/include/noether_gui/widgets/collapsible_area_widget.h
@@ -38,7 +38,10 @@ public:
     return widget;
   }
 
+  QString getLabel() const;
+
 private:
+  QString label_;
   QGridLayout* layout;
   QToolButton* tool_button;
   QFrame* line;

--- a/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
@@ -23,7 +23,7 @@ public:
 
   DirectionGenerator::ConstPtr create() const override;
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 private:
   Ui::Vector3dEditor* ui_;
@@ -37,7 +37,7 @@ public:
 
   DirectionGenerator::ConstPtr create() const override;
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 private:
   QFormLayout* layout_;

--- a/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
@@ -19,7 +19,7 @@ class FixedDirectionGeneratorWidget : public DirectionGeneratorWidget
 {
   Q_OBJECT
 public:
-  FixedDirectionGeneratorWidget(QWidget* parent = nullptr);
+  FixedDirectionGeneratorWidget(QWidget* parent = nullptr, const Eigen::Vector3d& = Eigen::Vector3d::UnitX());
 
   DirectionGenerator::ConstPtr create() const override;
 
@@ -31,7 +31,7 @@ class PrincipalAxisDirectionGeneratorWidget : public DirectionGeneratorWidget
 {
   Q_OBJECT
 public:
-  PrincipalAxisDirectionGeneratorWidget(QWidget* parent = nullptr);
+  PrincipalAxisDirectionGeneratorWidget(QWidget* parent = nullptr, const double rotation_offset = 0.0);
 
   DirectionGenerator::ConstPtr create() const override;
 

--- a/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
@@ -19,9 +19,11 @@ class FixedDirectionGeneratorWidget : public DirectionGeneratorWidget
 {
   Q_OBJECT
 public:
-  FixedDirectionGeneratorWidget(QWidget* parent = nullptr, const Eigen::Vector3d& = Eigen::Vector3d::UnitX());
+  FixedDirectionGeneratorWidget(QWidget* parent = nullptr);
 
   DirectionGenerator::ConstPtr create() const override;
+
+  void fromYAML(const YAML::Node&) override;
 
 private:
   Ui::Vector3dEditor* ui_;
@@ -31,9 +33,11 @@ class PrincipalAxisDirectionGeneratorWidget : public DirectionGeneratorWidget
 {
   Q_OBJECT
 public:
-  PrincipalAxisDirectionGeneratorWidget(QWidget* parent = nullptr, const double rotation_offset = 0.0);
+  PrincipalAxisDirectionGeneratorWidget(QWidget* parent = nullptr);
 
   DirectionGenerator::ConstPtr create() const override;
+
+  void fromYAML(const YAML::Node&) override;
 
 private:
   QFormLayout* layout_;

--- a/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/direction_generator_widgets.h
@@ -24,6 +24,7 @@ public:
   DirectionGenerator::ConstPtr create() const override;
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
 
 private:
   Ui::Vector3dEditor* ui_;
@@ -38,6 +39,7 @@ public:
   DirectionGenerator::ConstPtr create() const override;
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
 
 private:
   QFormLayout* layout_;

--- a/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
@@ -19,7 +19,7 @@ public:
 
   OriginGenerator::ConstPtr create() const override;
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 private:
   Ui::Vector3dEditor* ui_;

--- a/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
@@ -15,7 +15,7 @@ class FixedOriginGeneratorWidget : public OriginGeneratorWidget
 {
   Q_OBJECT
 public:
-  FixedOriginGeneratorWidget(QWidget* parent = nullptr);
+  FixedOriginGeneratorWidget(QWidget* parent = nullptr, const Eigen::Vector3d& dir = Eigen::Vector3d::Zero());
 
   OriginGenerator::ConstPtr create() const override;
 

--- a/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
@@ -15,9 +15,11 @@ class FixedOriginGeneratorWidget : public OriginGeneratorWidget
 {
   Q_OBJECT
 public:
-  FixedOriginGeneratorWidget(QWidget* parent = nullptr, const Eigen::Vector3d& dir = Eigen::Vector3d::Zero());
+  FixedOriginGeneratorWidget(QWidget* parent = nullptr);
 
   OriginGenerator::ConstPtr create() const override;
+
+  void fromYAML(const YAML::Node&) override;
 
 private:
   Ui::Vector3dEditor* ui_;

--- a/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/origin_generator_widgets.h
@@ -20,6 +20,7 @@ public:
   OriginGenerator::ConstPtr create() const override;
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
 
 private:
   Ui::Vector3dEditor* ui_;

--- a/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
@@ -14,7 +14,7 @@ public:
 
   ToolPathPlanner::ConstPtr create() const override final;
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 private:
   QDoubleSpinBox* search_radius_;

--- a/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
@@ -10,15 +10,11 @@ class PlaneSlicerRasterPlannerWidget : public RasterPlannerWidget
 {
   Q_OBJECT
 public:
-  PlaneSlicerRasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
-                                 QWidget* parent = nullptr,
-                                 const double line_spacing = 0.1,
-                                 const double point_spacing = 0.025,
-                                 const double min_hole_size = 0.1,
-                                 const double search_radius = 0.025,
-                                 const double min_segment_size = 0.1);
+  PlaneSlicerRasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
 
   ToolPathPlanner::ConstPtr create() const override final;
+
+  void fromYAML(const YAML::Node&) override;
 
 private:
   QDoubleSpinBox* search_radius_;

--- a/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
@@ -15,6 +15,7 @@ public:
   ToolPathPlanner::ConstPtr create() const override final;
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
 
 private:
   QDoubleSpinBox* search_radius_;

--- a/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plane_slicer_raster_planner_widget.h
@@ -10,7 +10,13 @@ class PlaneSlicerRasterPlannerWidget : public RasterPlannerWidget
 {
   Q_OBJECT
 public:
-  PlaneSlicerRasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
+  PlaneSlicerRasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
+                                 QWidget* parent = nullptr,
+                                 const double line_spacing = 0.1,
+                                 const double point_spacing = 0.025,
+                                 const double min_hole_size = 0.1,
+                                 const double search_radius = 0.025,
+                                 const double min_segment_size = 0.1);
 
   ToolPathPlanner::ConstPtr create() const override final;
 

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
@@ -29,6 +29,8 @@ public:
   void configure(const YAML::Node& config);
   void save(YAML::Node& config) const;
 
+  void removeWidgets();
+
 private:
   void addWidget(const QString& plugin_name, const YAML::Node& config);
 

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
@@ -8,6 +8,11 @@ namespace Ui
 class PluginLoader;
 }
 
+namespace YAML
+{
+class Node;
+}
+
 namespace noether
 {
 /**
@@ -20,8 +25,11 @@ public:
   PluginLoaderWidget(boost_plugin_loader::PluginLoader loader, const QString& title, QWidget* parent = nullptr);
 
   QWidgetList getWidgets() const;
+  void configure(const YAML::Node& config);
 
 private:
+  void addWidget(const QString& plugin_name, const YAML::Node& config);
+
   Ui::PluginLoader* ui_;
   const boost_plugin_loader::PluginLoader loader_;
 };

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
@@ -25,7 +25,9 @@ public:
   PluginLoaderWidget(boost_plugin_loader::PluginLoader loader, const QString& title, QWidget* parent = nullptr);
 
   QWidgetList getWidgets() const;
+
   void configure(const YAML::Node& config);
+  void save(YAML::Node& config) const;
 
 private:
   void addWidget(const QString& plugin_name, const YAML::Node& config);

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
@@ -114,8 +114,8 @@ void PluginLoaderWidget<PluginT>::save(YAML::Node& config) const
         if (widget)
         {
           YAML::Node widget_config;
-          widget->save(widget_config);
           widget_config["name"] = collapsible_area->getLabel().toStdString();
+          widget->save(widget_config);
 
           config.push_back(widget_config);
         }

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
@@ -99,4 +99,29 @@ void PluginLoaderWidget<PluginT>::configure(const YAML::Node& config)
   }
 }
 
+template <typename PluginT>
+void PluginLoaderWidget<PluginT>::save(YAML::Node& config) const
+{
+  for (int i = 0; i < ui_->vertical_layout_plugins->count(); ++i)
+  {
+    QLayoutItem* item = ui_->vertical_layout_plugins->itemAt(i);
+    if (item)
+    {
+      auto collapsible_area = dynamic_cast<const CollapsibleArea*>(item->widget());
+      if (collapsible_area)
+      {
+        auto widget = dynamic_cast<const typename PluginT::WidgetT*>(collapsible_area->getWidget());
+        if (widget)
+        {
+          YAML::Node widget_config;
+          widget->save(widget_config);
+          widget_config["name"] = collapsible_area->getLabel().toStdString();
+
+          config.push_back(widget_config);
+        }
+      }
+    }
+  }
+}
+
 }  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
@@ -24,7 +24,14 @@ PluginLoaderWidget<PluginT>::PluginLoaderWidget(boost_plugin_loader::PluginLoade
     const QString plugin_name = ui_->combo_box->currentText();
     if (!plugin_name.isEmpty())
     {
-      addWidget(plugin_name, {});
+      try
+      {
+        addWidget(plugin_name, {});
+      }
+      catch (const std::exception& ex)
+      {
+        QMessageBox::warning(this, "Error", QString::fromStdString(ex.what()));
+      }
     }
   });
 }
@@ -32,35 +39,28 @@ PluginLoaderWidget<PluginT>::PluginLoaderWidget(boost_plugin_loader::PluginLoade
 template <typename PluginT>
 void PluginLoaderWidget<PluginT>::addWidget(const QString& plugin_name, const YAML::Node& config)
 {
-  try
-  {
-    auto plugin = loader_.createInstance<PluginT>(plugin_name.toStdString());
+  auto plugin = loader_.createInstance<PluginT>(plugin_name.toStdString());
 
-    auto collapsible_area = new CollapsibleArea(plugin_name, this);
-    collapsible_area->setWidget(plugin->create(this, config));
-    collapsible_area->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+  auto collapsible_area = new CollapsibleArea(plugin_name, this);
+  collapsible_area->setWidget(plugin->create(this, config));
+  collapsible_area->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
 
-    ui_->vertical_layout_plugins->addWidget(collapsible_area);
+  ui_->vertical_layout_plugins->addWidget(collapsible_area);
 
-    // Add a right click menu option for deleting this tool path modifier widget
-    connect(collapsible_area, &QWidget::customContextMenuRequested, [this, collapsible_area](const QPoint& pos) {
-      QMenu context_menu;
-      QAction* remove_action = context_menu.addAction("Remove");
-      QAction* action = context_menu.exec(collapsible_area->mapToGlobal(pos));
-      if (action == remove_action)
-      {
-        ui_->vertical_layout_plugins->removeWidget(collapsible_area);
-        delete collapsible_area;
-      }
-    });
+  // Add a right click menu option for deleting this tool path modifier widget
+  connect(collapsible_area, &QWidget::customContextMenuRequested, [this, collapsible_area](const QPoint& pos) {
+    QMenu context_menu;
+    QAction* remove_action = context_menu.addAction("Remove");
+    QAction* action = context_menu.exec(collapsible_area->mapToGlobal(pos));
+    if (action == remove_action)
+    {
+      ui_->vertical_layout_plugins->removeWidget(collapsible_area);
+      delete collapsible_area;
+    }
+  });
 
-    // Reset the combo box to the blank value
-    ui_->combo_box->setCurrentIndex(0);
-  }
-  catch (const std::exception& ex)
-  {
-    QMessageBox::warning(this, "Error", QString::fromStdString(ex.what()));
-  }
+  // Reset the combo box to the blank value
+  ui_->combo_box->setCurrentIndex(0);
 }
 
 template <typename PluginT>
@@ -86,16 +86,10 @@ QWidgetList PluginLoaderWidget<PluginT>::getWidgets() const
 template <typename PluginT>
 void PluginLoaderWidget<PluginT>::configure(const YAML::Node& config)
 {
-  try
+  removeWidgets();
+  for (auto it = config.begin(); it != config.end(); ++it)
   {
-    for (auto it = config.begin(); it != config.end(); ++it)
-    {
-      addWidget(QString::fromStdString(getEntry<std::string>(*it, "name")), *it);
-    }
-  }
-  catch (const std::exception& ex)
-  {
-    QMessageBox::warning(this, "Configuration Error", ex.what());
+    addWidget(QString::fromStdString(getEntry<std::string>(*it, "name")), *it);
   }
 }
 
@@ -121,6 +115,15 @@ void PluginLoaderWidget<PluginT>::save(YAML::Node& config) const
         }
       }
     }
+  }
+}
+
+template <typename PluginT>
+void PluginLoaderWidget<PluginT>::removeWidgets()
+{
+  for (int i = 0; i < ui_->vertical_layout_plugins->count(); ++i)
+  {
+    ui_->vertical_layout_plugins->itemAt(i)->widget()->deleteLater();
   }
 }
 

--- a/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
@@ -22,7 +22,7 @@ class RasterPlannerWidget : public ToolPathPlannerWidget
 public:
   RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 protected:
   DirectionGeneratorWidget* getDirectionGeneratorWidget() const;

--- a/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
@@ -23,6 +23,7 @@ public:
   RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
 
 protected:
   DirectionGeneratorWidget* getDirectionGeneratorWidget() const;

--- a/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
@@ -10,6 +10,11 @@ namespace Ui
 class RasterPlanner;
 }
 
+namespace YAML
+{
+class Node;
+}
+
 namespace noether
 {
 class RasterPlannerWidget : public ToolPathPlannerWidget
@@ -22,6 +27,9 @@ public:
 protected:
   DirectionGeneratorWidget* getDirectionGeneratorWidget() const;
   OriginGeneratorWidget* getOriginGeneratorWidget() const;
+
+  void setDirectionGeneratorWidget(const QString& plugin_name, const YAML::Node& config);
+  void setOriginGeneratorWidget(const QString& plugin_name, const YAML::Node& config);
 
   const boost_plugin_loader::PluginLoader loader_;
   Ui::RasterPlanner* ui_;

--- a/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
@@ -15,7 +15,11 @@ namespace noether
 class RasterPlannerWidget : public ToolPathPlannerWidget
 {
 public:
-  RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
+  RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
+                      QWidget* parent = nullptr,
+                      const double line_spacing = 0.1,
+                      const double point_spacing = 0.025,
+                      const double min_hole_size = 0.1);
 
 protected:
   DirectionGeneratorWidget* getDirectionGeneratorWidget() const;

--- a/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/raster_planner_widget.h
@@ -15,11 +15,9 @@ namespace noether
 class RasterPlannerWidget : public ToolPathPlannerWidget
 {
 public:
-  RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
-                      QWidget* parent = nullptr,
-                      const double line_spacing = 0.1,
-                      const double point_spacing = 0.025,
-                      const double min_hole_size = 0.1);
+  RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent = nullptr);
+
+  void fromYAML(const YAML::Node&) override;
 
 protected:
   DirectionGeneratorWidget* getDirectionGeneratorWidget() const;

--- a/noether_gui/include/noether_gui/widgets/tool_path_modifier_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_modifier_widgets.h
@@ -23,6 +23,8 @@ public:
 
   ToolPathModifier::ConstPtr create() const override;
 
+  void fromYAML(const YAML::Node&) override;
+
 private:
   Ui::Vector3dEditor* ui_;
 };
@@ -52,6 +54,8 @@ public:
   FixedOrientationModifierWidget(QWidget* parent = nullptr);
   ToolPathModifier::ConstPtr create() const override;
 
+  void fromYAML(const YAML::Node&) override;
+
 private:
   Ui::Vector3dEditor* ui_;
 };
@@ -76,6 +80,8 @@ class MovingAverageOrientationSmoothingModifierWidget : public ToolPathModifierW
 public:
   MovingAverageOrientationSmoothingModifierWidget(QWidget* parent = nullptr);
   ToolPathModifier::ConstPtr create() const override;
+
+  void fromYAML(const YAML::Node&) override;
 
 private:
   QFormLayout* layout_;

--- a/noether_gui/include/noether_gui/widgets/tool_path_modifier_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_modifier_widgets.h
@@ -24,6 +24,7 @@ public:
   ToolPathModifier::ConstPtr create() const override;
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const;
 
 private:
   Ui::Vector3dEditor* ui_;
@@ -55,6 +56,7 @@ public:
   ToolPathModifier::ConstPtr create() const override;
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const;
 
 private:
   Ui::Vector3dEditor* ui_;
@@ -82,6 +84,7 @@ public:
   ToolPathModifier::ConstPtr create() const override;
 
   void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const;
 
 private:
   QFormLayout* layout_;

--- a/noether_gui/include/noether_gui/widgets/tool_path_modifier_widgets.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_modifier_widgets.h
@@ -23,7 +23,7 @@ public:
 
   ToolPathModifier::ConstPtr create() const override;
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 private:
   Ui::Vector3dEditor* ui_;
@@ -54,7 +54,7 @@ public:
   FixedOrientationModifierWidget(QWidget* parent = nullptr);
   ToolPathModifier::ConstPtr create() const override;
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 private:
   Ui::Vector3dEditor* ui_;
@@ -81,7 +81,7 @@ public:
   MovingAverageOrientationSmoothingModifierWidget(QWidget* parent = nullptr);
   ToolPathModifier::ConstPtr create() const override;
 
-  void fromYAML(const YAML::Node&) override;
+  void configure(const YAML::Node&) override;
 
 private:
   QFormLayout* layout_;

--- a/noether_gui/include/noether_gui/widgets/tpp_pipeline_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_pipeline_widget.h
@@ -28,6 +28,7 @@ public:
   ToolPathPlannerPipeline createPipeline() const;
 
   void configure(const YAML::Node& config);
+  void save(YAML::Node& config) const;
 
 private:
   const boost_plugin_loader::PluginLoader loader_;

--- a/noether_gui/include/noether_gui/widgets/tpp_pipeline_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_pipeline_widget.h
@@ -27,10 +27,12 @@ public:
 
   ToolPathPlannerPipeline createPipeline() const;
 
+  void configure(const YAML::Node& config);
+
 private:
   const boost_plugin_loader::PluginLoader loader_;
   PluginLoaderWidget<MeshModifierWidgetPlugin>* mesh_modifier_loader_widget_;
-  PluginLoaderWidget<ToolPathModifierWidgetPlugin>* tool_path_modifier_loader_widget;
+  PluginLoaderWidget<ToolPathModifierWidgetPlugin>* tool_path_modifier_loader_widget_;
   Ui::TPPPipeline* ui_;
 };
 

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -15,6 +15,8 @@ class TPP;
 
 namespace noether
 {
+class TPPPipelineWidget;
+
 /**
  * @brief Basic tool path planning widget
  * @details Allows the user to laod a mesh from file, configure a tool path planning pipeline, and generate tool paths
@@ -35,9 +37,12 @@ public:
 
 private:
   void onLoadMesh(const bool /*checked*/);
+  void onLoadConfiguration(const bool /*checked*/);
+  void onSaveConfiguration(const bool /*checked*/);
   void onPlan(const bool /*checked*/);
 
   Ui::TPP* ui_;
+  TPPPipelineWidget* pipeline_widget_;
   std::vector<ToolPaths> tool_paths_;
 };
 

--- a/noether_gui/package.xml
+++ b/noether_gui/package.xml
@@ -12,6 +12,7 @@
   <depend>libqt5-widgets</depend>
   <depend>noether_tpp</depend>
   <depend>boost_plugin_loader</depend>
+  <depend>yaml-cpp</depend>
 
   <export>
     <build_type>cmake</build_type>

--- a/noether_gui/src/plugin_interface.cpp
+++ b/noether_gui/src/plugin_interface.cpp
@@ -14,7 +14,7 @@ template <>
 std::string noether::ToolPathPlannerWidgetPlugin::getSection()
 {
   return "tpp";
-};
+}
 
 template <>
 std::string DirectionGeneratorWidgetPlugin::getSection()
@@ -43,10 +43,10 @@ std::string MeshModifierWidgetPlugin::getSection()
 
 namespace boost_plugin_loader
 {
-INSTANTIATE_PLUGIN_LOADER(noether::ToolPathPlannerWidgetPlugin);
-INSTANTIATE_PLUGIN_LOADER(noether::DirectionGeneratorWidgetPlugin);
-INSTANTIATE_PLUGIN_LOADER(noether::OriginGeneratorWidgetPlugin);
-INSTANTIATE_PLUGIN_LOADER(noether::ToolPathModifierWidgetPlugin);
-INSTANTIATE_PLUGIN_LOADER(noether::MeshModifierWidgetPlugin);
+INSTANTIATE_PLUGIN_LOADER(noether::ToolPathPlannerWidgetPlugin)
+INSTANTIATE_PLUGIN_LOADER(noether::DirectionGeneratorWidgetPlugin)
+INSTANTIATE_PLUGIN_LOADER(noether::OriginGeneratorWidgetPlugin)
+INSTANTIATE_PLUGIN_LOADER(noether::ToolPathModifierWidgetPlugin)
+INSTANTIATE_PLUGIN_LOADER(noether::MeshModifierWidgetPlugin)
 
 }  // namespace boost_plugin_loader

--- a/noether_gui/src/plugin_interface.cpp
+++ b/noether_gui/src/plugin_interface.cpp
@@ -13,31 +13,31 @@ namespace noether
 template <>
 std::string noether::ToolPathPlannerWidgetPlugin::getSection()
 {
-  return "tpp";
+  return NOETHER_GUI_TPP_SECTION;
 }
 
 template <>
 std::string DirectionGeneratorWidgetPlugin::getSection()
 {
-  return "dg";
+  return NOETHER_GUI_DIRECTION_GENERATOR_SECTION;
 }
 
 template <>
 std::string OriginGeneratorWidgetPlugin::getSection()
 {
-  return "og";
+  return NOETHER_GUI_ORIGIN_GENERATOR_SECTION;
 }
 
 template <>
 std::string ToolPathModifierWidgetPlugin::getSection()
 {
-  return "mod";
+  return NOETHER_GUI_TOOL_PATH_MODIFIER_SECTION;
 }
 
 template <>
 std::string MeshModifierWidgetPlugin::getSection()
 {
-  return "mesh";
+  return NOETHER_GUI_MESH_MODIFIER_SECTION;
 }
 }  // namespace noether
 

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -18,18 +18,9 @@ struct WidgetPluginImpl : WidgetPlugin<BaseT>
   {
     auto widget = new T(parent);
 
+    // Attempt to configure the widget
     if (!config.IsNull())
-    {
-      // Attempt to configure the widget
-      try
-      {
-        widget->configure(config);
-      }
-      catch (const std::exception& ex)
-      {
-        QMessageBox::warning(widget, "Configuration error", ex.what());
-      }
-    }
+      widget->configure(config);
 
     return widget;
   }
@@ -87,18 +78,9 @@ struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
     loader.search_libraries.insert(NOETHER_GUI_PLUGINS);
     auto widget = new PlaneSlicerRasterPlannerWidget(std::move(loader), parent);
 
+    // Attempt to configure the widget
     if (!config.IsNull())
-    {
-      // Attempt to configure the widget
-      try
-      {
-        widget->configure(config);
-      }
-      catch (const std::exception& ex)
-      {
-        QMessageBox::warning(widget, "Configuration error", ex.what());
-      }
-    }
+      widget->configure(config);
 
     return widget;
   }

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -23,7 +23,7 @@ struct WidgetPluginImpl : WidgetPlugin<BaseT>
       // Attempt to configure the widget
       try
       {
-        widget->fromYAML(config);
+        widget->configure(config);
       }
       catch (const std::exception& ex)
       {
@@ -92,7 +92,7 @@ struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
       // Attempt to configure the widget
       try
       {
-        widget->fromYAML(config);
+        widget->configure(config);
       }
       catch (const std::exception& ex)
       {

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -13,7 +13,7 @@ namespace noether
 template <typename T, typename BaseT>
 struct WidgetPluginImpl : WidgetPlugin<BaseT>
 {
-  QWidget* create(QWidget* parent = nullptr) const override final { return new T(parent); }
+  QWidget* create(QWidget* parent = nullptr, const YAML::Node& = {}) const override final { return new T(parent); }
 };
 
 // Direction Generators
@@ -61,7 +61,7 @@ using LeadOutToolPathModifierWidgetPlugin =
 // Raster Tool Path Planners
 struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
 {
-  QWidget* create(QWidget* parent = nullptr) const override final
+  QWidget* create(QWidget* parent = nullptr, const YAML::Node& = {}) const override final
   {
     boost_plugin_loader::PluginLoader loader;
     loader.search_libraries.insert(NOETHER_GUI_PLUGINS);

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -7,6 +7,7 @@
 #include <noether_gui/widgets/plane_slicer_raster_planner_widget.h>
 
 #include <QWidget>
+#include <QMessageBox>
 
 namespace noether
 {
@@ -17,14 +18,17 @@ struct WidgetPluginImpl : WidgetPlugin<BaseT>
   {
     auto widget = new T(parent);
 
-    // Attempt to deserialize
-    try
+    if (!config.IsNull())
     {
-      widget->fromYAML(config);
-    }
-    catch (const std::exception& /*ex*/)
-    {
-      // Document
+      // Attempt to configure the widget
+      try
+      {
+        widget->fromYAML(config);
+      }
+      catch (const std::exception& ex)
+      {
+        QMessageBox::warning(widget, "Configuration error", ex.what());
+      }
     }
 
     return widget;
@@ -83,14 +87,17 @@ struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
     loader.search_libraries.insert(NOETHER_GUI_PLUGINS);
     auto widget = new PlaneSlicerRasterPlannerWidget(std::move(loader), parent);
 
-    // Load the parameters
-    try
+    if (!config.IsNull())
     {
-      widget->fromYAML(config);
-    }
-    catch (const std::exception&)
-    {
-      //
+      // Attempt to configure the widget
+      try
+      {
+        widget->fromYAML(config);
+      }
+      catch (const std::exception& ex)
+      {
+        QMessageBox::warning(widget, "Configuration error", ex.what());
+      }
     }
 
     return widget;

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -63,10 +63,10 @@ using MovingAverageOrientationSmoothingModifierWidgetPlugin =
 using ToolDragOrientationToolPathModifierWidgetPlugin =
     WidgetPluginImpl<ToolDragOrientationToolPathModifierWidget, ToolPathModifierWidget>;
 
-using LeadInToolPathModifierWidgetPlugin =
+using CircularLeadInToolPathModifierWidgetPlugin =
     WidgetPluginImpl<CircularLeadInToolPathModifierWidget, ToolPathModifierWidget>;
 
-using LeadOutToolPathModifierWidgetPlugin =
+using CircularLeadOutToolPathModifierWidgetPlugin =
     WidgetPluginImpl<CircularLeadOutToolPathModifierWidget, ToolPathModifierWidget>;
 
 // Raster Tool Path Planners
@@ -108,7 +108,7 @@ EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::MovingAverageOrientationSmoothi
                                         MovingAverageOrientationSmoothingModifier)
 EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::ToolDragOrientationToolPathModifierWidgetPlugin,
                                         ToolDragOrientationToolPathModifier)
-EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::LeadInToolPathModifierWidgetPlugin, LeadInModifier)
-EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::LeadOutToolPathModifierWidgetPlugin, LeadOutModifier)
+EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::CircularLeadInToolPathModifierWidgetPlugin, CircularLeadInModifier)
+EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::CircularLeadOutToolPathModifierWidgetPlugin, CircularLeadOutModifier)
 
 EXPORT_TPP_WIDGET_PLUGIN(noether::PlaneSlicerRasterPlannerWidgetPlugin, PlaneSlicerRasterPlanner)

--- a/noether_gui/src/widgets/blending_tool_path_modifier_widgets.cpp
+++ b/noether_gui/src/widgets/blending_tool_path_modifier_widgets.cpp
@@ -1,11 +1,18 @@
 #include <noether_gui/widgets/blending_tool_path_modifier_widgets.h>
-#include <noether_tpp/tool_path_modifiers/blending_modifiers.h>
+#include <noether_gui/utils.h>
 
+#include <noether_tpp/tool_path_modifiers/blending_modifiers.h>
 #include <QFormLayout>
 #include <QLabel>
 #include <QDoubleSpinBox>
 #include <QSpinBox>
 #include <QCheckBox>
+
+static const std::string ANGLE_OFFSET_KEY = "angle_offset";
+static const std::string TOOL_RADIUS_KEY = "tool_radius";
+static const std::string ARC_ANGLE_KEY = "arc_angle";
+static const std::string ARC_RADIUS_KEY = "arc_radius";
+static const std::string N_POINTS_KEY = "n_points";
 
 namespace noether
 {
@@ -37,6 +44,18 @@ ToolPathModifier::ConstPtr ToolDragOrientationToolPathModifierWidget::create() c
 {
   return std::make_unique<ToolDragOrientationToolPathModifier>(angle_offset_->value() * M_PI / 180.0,
                                                                tool_radius_->value());
+}
+
+void ToolDragOrientationToolPathModifierWidget::configure(const YAML::Node& config)
+{
+  angle_offset_->setValue(getEntry<double>(config, ANGLE_OFFSET_KEY));
+  tool_radius_->setValue(getEntry<double>(config, TOOL_RADIUS_KEY));
+}
+
+void ToolDragOrientationToolPathModifierWidget::save(YAML::Node& config) const
+{
+  config[ANGLE_OFFSET_KEY] = angle_offset_->value();
+  config[TOOL_RADIUS_KEY] = tool_radius_->value();
 }
 
 CircularLeadInToolPathModifierWidget::CircularLeadInToolPathModifierWidget(QWidget* parent)
@@ -81,6 +100,20 @@ ToolPathModifier::ConstPtr CircularLeadInToolPathModifierWidget::create() const
       arc_angle_->value() * M_PI / 180.0, arc_radius_->value(), n_points_->value());
 }
 
+void CircularLeadInToolPathModifierWidget::configure(const YAML::Node& config)
+{
+  arc_angle_->setValue(getEntry<double>(config, ARC_ANGLE_KEY));
+  arc_radius_->setValue(getEntry<double>(config, ARC_RADIUS_KEY));
+  n_points_->setValue(getEntry<int>(config, N_POINTS_KEY));
+}
+
+void CircularLeadInToolPathModifierWidget::save(YAML::Node& config) const
+{
+  config[ARC_ANGLE_KEY] = arc_angle_->value();
+  config[ARC_RADIUS_KEY] = arc_radius_->value();
+  config[N_POINTS_KEY] = n_points_->value();
+}
+
 CircularLeadOutToolPathModifierWidget::CircularLeadOutToolPathModifierWidget(QWidget* parent)
   : ToolPathModifierWidget(parent)
 {
@@ -123,6 +156,20 @@ ToolPathModifier::ConstPtr CircularLeadOutToolPathModifierWidget::create() const
 {
   return std::make_unique<CircularLeadOutModifier>(
       arc_angle_->value() * M_PI / 180.0, arc_radius_->value(), n_points_->value());
+}
+
+void CircularLeadOutToolPathModifierWidget::configure(const YAML::Node& config)
+{
+  arc_angle_->setValue(getEntry<double>(config, ARC_ANGLE_KEY));
+  arc_radius_->setValue(getEntry<double>(config, ARC_RADIUS_KEY));
+  n_points_->setValue(getEntry<int>(config, N_POINTS_KEY));
+}
+
+void CircularLeadOutToolPathModifierWidget::save(YAML::Node& config) const
+{
+  config[ARC_ANGLE_KEY] = arc_angle_->value();
+  config[ARC_RADIUS_KEY] = arc_radius_->value();
+  config[N_POINTS_KEY] = n_points_->value();
 }
 
 }  // namespace noether

--- a/noether_gui/src/widgets/blending_tool_path_modifier_widgets.cpp
+++ b/noether_gui/src/widgets/blending_tool_path_modifier_widgets.cpp
@@ -107,14 +107,14 @@ CircularLeadOutToolPathModifierWidget::CircularLeadOutToolPathModifierWidget(QWi
   layout->addRow(label_rad, arc_radius_);
 
   // Number of points
-  n_points = new QSpinBox(this);
-  n_points->setMinimum(0.0);
-  n_points->setSingleStep(1);
-  n_points->setValue(5);
+  n_points_ = new QSpinBox(this);
+  n_points_->setMinimum(0.0);
+  n_points_->setSingleStep(1);
+  n_points_->setValue(5);
 
   auto label_pnt = new QLabel("Lead in number of points", this);
   label_pnt->setToolTip("Number of waypoints along the exit trajectory");
-  layout->addRow(label_pnt, n_points);
+  layout->addRow(label_pnt, n_points_);
 
   setLayout(layout);
 }
@@ -122,7 +122,7 @@ CircularLeadOutToolPathModifierWidget::CircularLeadOutToolPathModifierWidget(QWi
 ToolPathModifier::ConstPtr CircularLeadOutToolPathModifierWidget::create() const
 {
   return std::make_unique<CircularLeadOutModifier>(
-      arc_angle_->value() * M_PI / 180.0, arc_radius_->value(), n_points->value());
+      arc_angle_->value() * M_PI / 180.0, arc_radius_->value(), n_points_->value());
 }
 
 }  // namespace noether

--- a/noether_gui/src/widgets/collapsible_area_widget.cpp
+++ b/noether_gui/src/widgets/collapsible_area_widget.cpp
@@ -13,6 +13,7 @@ namespace noether
 {
 CollapsibleArea::CollapsibleArea(const QString& label, QWidget* parent)
   : QWidget(parent)
+  , label_(label)
   , layout(new QGridLayout(this))
   , tool_button(new QToolButton(this))
   , line(new QFrame(this))
@@ -92,5 +93,7 @@ void CollapsibleArea::setWidget(QWidget* widget)
 }
 
 QWidget* CollapsibleArea::getWidget() const { return content->widget(); }
+
+QString CollapsibleArea::getLabel() const { return label_; }
 
 }  // namespace noether

--- a/noether_gui/src/widgets/direction_generator_widgets.cpp
+++ b/noether_gui/src/widgets/direction_generator_widgets.cpp
@@ -18,7 +18,7 @@ FixedDirectionGeneratorWidget::FixedDirectionGeneratorWidget(QWidget* parent)
   ui_->group_box->setTitle("Direction");
 }
 
-void FixedDirectionGeneratorWidget::fromYAML(const YAML::Node& config)
+void FixedDirectionGeneratorWidget::configure(const YAML::Node& config)
 {
   Eigen::Vector3d dir(getEntry<double>(config, "x"), getEntry<double>(config, "y"), getEntry<double>(config, "z"));
   dir.normalize();
@@ -48,7 +48,7 @@ PrincipalAxisDirectionGeneratorWidget::PrincipalAxisDirectionGeneratorWidget(QWi
   rotation_offset_->setDecimals(3);
 }
 
-void PrincipalAxisDirectionGeneratorWidget::fromYAML(const YAML::Node& config)
+void PrincipalAxisDirectionGeneratorWidget::configure(const YAML::Node& config)
 {
   rotation_offset_->setValue(getEntry<double>(config, "rotation_offset"));
 }

--- a/noether_gui/src/widgets/direction_generator_widgets.cpp
+++ b/noether_gui/src/widgets/direction_generator_widgets.cpp
@@ -1,19 +1,27 @@
 #include <noether_gui/widgets/direction_generator_widgets.h>
 #include "ui_vector3d_editor_widget.h"
+#include <noether_gui/utils.h>
 
 #include <noether_tpp/tool_path_planners/raster/direction_generators.h>
 #include <QFormLayout>
 #include <QLabel>
 #include <QDoubleSpinBox>
 #include <QGroupBox>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
-FixedDirectionGeneratorWidget::FixedDirectionGeneratorWidget(QWidget* parent, const Eigen::Vector3d& dir)
+FixedDirectionGeneratorWidget::FixedDirectionGeneratorWidget(QWidget* parent)
   : DirectionGeneratorWidget(parent), ui_(new Ui::Vector3dEditor())
 {
   ui_->setupUi(this);
   ui_->group_box->setTitle("Direction");
+}
+
+void FixedDirectionGeneratorWidget::fromYAML(const YAML::Node& config)
+{
+  Eigen::Vector3d dir(getEntry<double>(config, "x"), getEntry<double>(config, "y"), getEntry<double>(config, "z"));
+  dir.normalize();
 
   ui_->double_spin_box_x->setValue(dir.x());
   ui_->double_spin_box_y->setValue(dir.y());
@@ -28,17 +36,21 @@ DirectionGenerator::ConstPtr FixedDirectionGeneratorWidget::create() const
   return std::make_unique<FixedDirectionGenerator>(dir);
 }
 
-PrincipalAxisDirectionGeneratorWidget::PrincipalAxisDirectionGeneratorWidget(QWidget* parent,
-                                                                             const double rotation_offset)
+PrincipalAxisDirectionGeneratorWidget::PrincipalAxisDirectionGeneratorWidget(QWidget* parent)
   : DirectionGeneratorWidget(parent)
   , layout_(new QFormLayout(this))
   , label_(new QLabel("Rotation offset (deg)", this))
   , rotation_offset_(new QDoubleSpinBox(this))
 {
   layout_->addRow(label_, rotation_offset_);
-  rotation_offset_->setValue(rotation_offset);
+  rotation_offset_->setValue(0.0);
   rotation_offset_->setRange(-180.0, 180.0);
   rotation_offset_->setDecimals(3);
+}
+
+void PrincipalAxisDirectionGeneratorWidget::fromYAML(const YAML::Node& config)
+{
+  rotation_offset_->setValue(getEntry<double>(config, "rotation_offset"));
 }
 
 DirectionGenerator::ConstPtr PrincipalAxisDirectionGeneratorWidget::create() const

--- a/noether_gui/src/widgets/direction_generator_widgets.cpp
+++ b/noether_gui/src/widgets/direction_generator_widgets.cpp
@@ -9,14 +9,15 @@
 
 namespace noether
 {
-FixedDirectionGeneratorWidget::FixedDirectionGeneratorWidget(QWidget* parent)
+FixedDirectionGeneratorWidget::FixedDirectionGeneratorWidget(QWidget* parent, const Eigen::Vector3d& dir)
   : DirectionGeneratorWidget(parent), ui_(new Ui::Vector3dEditor())
 {
   ui_->setupUi(this);
   ui_->group_box->setTitle("Direction");
 
-  // Set the x value to 1.0 by default
-  ui_->double_spin_box_x->setValue(1.0);
+  ui_->double_spin_box_x->setValue(dir.x());
+  ui_->double_spin_box_y->setValue(dir.y());
+  ui_->double_spin_box_z->setValue(dir.z());
 }
 
 DirectionGenerator::ConstPtr FixedDirectionGeneratorWidget::create() const
@@ -27,14 +28,15 @@ DirectionGenerator::ConstPtr FixedDirectionGeneratorWidget::create() const
   return std::make_unique<FixedDirectionGenerator>(dir);
 }
 
-PrincipalAxisDirectionGeneratorWidget::PrincipalAxisDirectionGeneratorWidget(QWidget* parent)
+PrincipalAxisDirectionGeneratorWidget::PrincipalAxisDirectionGeneratorWidget(QWidget* parent,
+                                                                             const double rotation_offset)
   : DirectionGeneratorWidget(parent)
   , layout_(new QFormLayout(this))
   , label_(new QLabel("Rotation offset (deg)", this))
   , rotation_offset_(new QDoubleSpinBox(this))
 {
   layout_->addRow(label_, rotation_offset_);
-  rotation_offset_->setValue(0.0);
+  rotation_offset_->setValue(rotation_offset);
   rotation_offset_->setRange(-180.0, 180.0);
   rotation_offset_->setDecimals(3);
 }

--- a/noether_gui/src/widgets/direction_generator_widgets.cpp
+++ b/noether_gui/src/widgets/direction_generator_widgets.cpp
@@ -16,6 +16,8 @@ FixedDirectionGeneratorWidget::FixedDirectionGeneratorWidget(QWidget* parent)
 {
   ui_->setupUi(this);
   ui_->group_box->setTitle("Direction");
+
+  ui_->double_spin_box_x->setValue(1.0);
 }
 
 void FixedDirectionGeneratorWidget::configure(const YAML::Node& config)
@@ -31,8 +33,8 @@ void FixedDirectionGeneratorWidget::configure(const YAML::Node& config)
 void FixedDirectionGeneratorWidget::save(YAML::Node& config) const
 {
   config["x"] = ui_->double_spin_box_x->value();
-  config["y"] = ui_->double_spin_box_x->value();
-  config["z"] = ui_->double_spin_box_x->value();
+  config["y"] = ui_->double_spin_box_y->value();
+  config["z"] = ui_->double_spin_box_z->value();
 }
 
 DirectionGenerator::ConstPtr FixedDirectionGeneratorWidget::create() const

--- a/noether_gui/src/widgets/direction_generator_widgets.cpp
+++ b/noether_gui/src/widgets/direction_generator_widgets.cpp
@@ -28,6 +28,13 @@ void FixedDirectionGeneratorWidget::configure(const YAML::Node& config)
   ui_->double_spin_box_z->setValue(dir.z());
 }
 
+void FixedDirectionGeneratorWidget::save(YAML::Node& config) const
+{
+  config["x"] = ui_->double_spin_box_x->value();
+  config["y"] = ui_->double_spin_box_x->value();
+  config["z"] = ui_->double_spin_box_x->value();
+}
+
 DirectionGenerator::ConstPtr FixedDirectionGeneratorWidget::create() const
 {
   Eigen::Vector3d dir(
@@ -51,6 +58,11 @@ PrincipalAxisDirectionGeneratorWidget::PrincipalAxisDirectionGeneratorWidget(QWi
 void PrincipalAxisDirectionGeneratorWidget::configure(const YAML::Node& config)
 {
   rotation_offset_->setValue(getEntry<double>(config, "rotation_offset"));
+}
+
+void PrincipalAxisDirectionGeneratorWidget::save(YAML::Node& config) const
+{
+  config["rotation_offset"] = rotation_offset_->value();
 }
 
 DirectionGenerator::ConstPtr PrincipalAxisDirectionGeneratorWidget::create() const

--- a/noether_gui/src/widgets/origin_generator_widgets.cpp
+++ b/noether_gui/src/widgets/origin_generator_widgets.cpp
@@ -21,6 +21,13 @@ void FixedOriginGeneratorWidget::configure(const YAML::Node& config)
   ui_->double_spin_box_z->setValue(getEntry<double>(config, "z"));
 }
 
+void FixedOriginGeneratorWidget::save(YAML::Node& config) const
+{
+  config["x"] = ui_->double_spin_box_x->value();
+  config["y"] = ui_->double_spin_box_x->value();
+  config["z"] = ui_->double_spin_box_x->value();
+}
+
 OriginGenerator::ConstPtr FixedOriginGeneratorWidget::create() const
 {
   Eigen::Vector3d origin(

--- a/noether_gui/src/widgets/origin_generator_widgets.cpp
+++ b/noether_gui/src/widgets/origin_generator_widgets.cpp
@@ -1,19 +1,24 @@
 #include <noether_gui/widgets/origin_generator_widgets.h>
 #include "ui_vector3d_editor_widget.h"
+#include <noether_gui/utils.h>
 
 #include <noether_tpp/tool_path_planners/raster/origin_generators.h>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
-FixedOriginGeneratorWidget::FixedOriginGeneratorWidget(QWidget* parent, const Eigen::Vector3d& dir)
+FixedOriginGeneratorWidget::FixedOriginGeneratorWidget(QWidget* parent)
   : OriginGeneratorWidget(parent), ui_(new Ui::Vector3dEditor())
 {
   ui_->setupUi(this);
   ui_->group_box->setTitle("Origin");
+}
 
-  ui_->double_spin_box_x->setValue(dir.x());
-  ui_->double_spin_box_y->setValue(dir.y());
-  ui_->double_spin_box_z->setValue(dir.z());
+void FixedOriginGeneratorWidget::fromYAML(const YAML::Node& config)
+{
+  ui_->double_spin_box_x->setValue(getEntry<double>(config, "x"));
+  ui_->double_spin_box_y->setValue(getEntry<double>(config, "y"));
+  ui_->double_spin_box_z->setValue(getEntry<double>(config, "z"));
 }
 
 OriginGenerator::ConstPtr FixedOriginGeneratorWidget::create() const

--- a/noether_gui/src/widgets/origin_generator_widgets.cpp
+++ b/noether_gui/src/widgets/origin_generator_widgets.cpp
@@ -14,7 +14,7 @@ FixedOriginGeneratorWidget::FixedOriginGeneratorWidget(QWidget* parent)
   ui_->group_box->setTitle("Origin");
 }
 
-void FixedOriginGeneratorWidget::fromYAML(const YAML::Node& config)
+void FixedOriginGeneratorWidget::configure(const YAML::Node& config)
 {
   ui_->double_spin_box_x->setValue(getEntry<double>(config, "x"));
   ui_->double_spin_box_y->setValue(getEntry<double>(config, "y"));

--- a/noether_gui/src/widgets/origin_generator_widgets.cpp
+++ b/noether_gui/src/widgets/origin_generator_widgets.cpp
@@ -5,11 +5,15 @@
 
 namespace noether
 {
-FixedOriginGeneratorWidget::FixedOriginGeneratorWidget(QWidget* parent)
+FixedOriginGeneratorWidget::FixedOriginGeneratorWidget(QWidget* parent, const Eigen::Vector3d& dir)
   : OriginGeneratorWidget(parent), ui_(new Ui::Vector3dEditor())
 {
   ui_->setupUi(this);
   ui_->group_box->setTitle("Origin");
+
+  ui_->double_spin_box_x->setValue(dir.x());
+  ui_->double_spin_box_y->setValue(dir.y());
+  ui_->double_spin_box_z->setValue(dir.z());
 }
 
 OriginGenerator::ConstPtr FixedOriginGeneratorWidget::create() const

--- a/noether_gui/src/widgets/origin_generator_widgets.cpp
+++ b/noether_gui/src/widgets/origin_generator_widgets.cpp
@@ -24,8 +24,8 @@ void FixedOriginGeneratorWidget::configure(const YAML::Node& config)
 void FixedOriginGeneratorWidget::save(YAML::Node& config) const
 {
   config["x"] = ui_->double_spin_box_x->value();
-  config["y"] = ui_->double_spin_box_x->value();
-  config["z"] = ui_->double_spin_box_x->value();
+  config["y"] = ui_->double_spin_box_y->value();
+  config["z"] = ui_->double_spin_box_z->value();
 }
 
 OriginGenerator::ConstPtr FixedOriginGeneratorWidget::create() const

--- a/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
@@ -43,9 +43,9 @@ PlaneSlicerRasterPlannerWidget::PlaneSlicerRasterPlannerWidget(boost_plugin_load
   ui_->group_box_raster_planner->layout()->addWidget(collapsible_area);
 }
 
-void PlaneSlicerRasterPlannerWidget::fromYAML(const YAML::Node& config)
+void PlaneSlicerRasterPlannerWidget::configure(const YAML::Node& config)
 {
-  RasterPlannerWidget::fromYAML(config);
+  RasterPlannerWidget::configure(config);
   search_radius_->setValue(getEntry<double>(config, "search_radius"));
   min_segment_size_->setValue(getEntry<double>(config, "min_segment_size"));
 }

--- a/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
@@ -11,8 +11,13 @@
 namespace noether
 {
 PlaneSlicerRasterPlannerWidget::PlaneSlicerRasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
-                                                               QWidget* parent)
-  : RasterPlannerWidget(std::move(loader), parent)
+                                                               QWidget* parent,
+                                                               const double line_spacing,
+                                                               const double point_spacing,
+                                                               const double min_hole_size,
+                                                               const double search_radius,
+                                                               const double min_segment_size)
+  : RasterPlannerWidget(std::move(loader), parent, line_spacing, point_spacing, min_hole_size)
   , search_radius_(new QDoubleSpinBox(this))
   , min_segment_size_(new QDoubleSpinBox(this))
 {
@@ -21,14 +26,14 @@ PlaneSlicerRasterPlannerWidget::PlaneSlicerRasterPlannerWidget(boost_plugin_load
   // Search radius
   search_radius_->setMinimum(0.0);
   search_radius_->setSingleStep(0.1);
-  search_radius_->setValue(0.025);
+  search_radius_->setValue(search_radius);
   search_radius_->setDecimals(3);
   layout->addRow(new QLabel("Search radius (m)", this), search_radius_);
 
   // Min segment length
   min_segment_size_->setMinimum(0.0);
   min_segment_size_->setSingleStep(0.1);
-  min_segment_size_->setValue(0.1);
+  min_segment_size_->setValue(min_segment_size);
   min_segment_size_->setDecimals(3);
   layout->addRow(new QLabel("Min. segment length", this), min_segment_size_);
 

--- a/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
@@ -50,6 +50,13 @@ void PlaneSlicerRasterPlannerWidget::configure(const YAML::Node& config)
   min_segment_size_->setValue(getEntry<double>(config, "min_segment_size"));
 }
 
+void PlaneSlicerRasterPlannerWidget::save(YAML::Node& config) const
+{
+  RasterPlannerWidget::save(config);
+  config["search_radius"] = search_radius_->value();
+  config["min_segment_size"] = min_segment_size_->value();
+}
+
 ToolPathPlanner::ConstPtr PlaneSlicerRasterPlannerWidget::create() const
 {
   DirectionGeneratorWidget* dir_gen_widget = getDirectionGeneratorWidget();

--- a/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/plane_slicer_raster_planner_widget.cpp
@@ -1,23 +1,20 @@
 #include <noether_gui/widgets/plane_slicer_raster_planner_widget.h>
 #include "ui_raster_planner_widget.h"
 #include <noether_gui/widgets/collapsible_area_widget.h>
+#include <noether_gui/utils.h>
 
 #include <noether_tpp/tool_path_planners/raster/plane_slicer_raster_planner.h>
 #include <QFormLayout>
 #include <QLabel>
 #include <QDoubleSpinBox>
 #include <QMessageBox>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
 PlaneSlicerRasterPlannerWidget::PlaneSlicerRasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
-                                                               QWidget* parent,
-                                                               const double line_spacing,
-                                                               const double point_spacing,
-                                                               const double min_hole_size,
-                                                               const double search_radius,
-                                                               const double min_segment_size)
-  : RasterPlannerWidget(std::move(loader), parent, line_spacing, point_spacing, min_hole_size)
+                                                               QWidget* parent)
+  : RasterPlannerWidget(std::move(loader), parent)
   , search_radius_(new QDoubleSpinBox(this))
   , min_segment_size_(new QDoubleSpinBox(this))
 {
@@ -26,14 +23,14 @@ PlaneSlicerRasterPlannerWidget::PlaneSlicerRasterPlannerWidget(boost_plugin_load
   // Search radius
   search_radius_->setMinimum(0.0);
   search_radius_->setSingleStep(0.1);
-  search_radius_->setValue(search_radius);
+  search_radius_->setValue(0.1);
   search_radius_->setDecimals(3);
   layout->addRow(new QLabel("Search radius (m)", this), search_radius_);
 
   // Min segment length
   min_segment_size_->setMinimum(0.0);
   min_segment_size_->setSingleStep(0.1);
-  min_segment_size_->setValue(min_segment_size);
+  min_segment_size_->setValue(0.1);
   min_segment_size_->setDecimals(3);
   layout->addRow(new QLabel("Min. segment length", this), min_segment_size_);
 
@@ -44,6 +41,13 @@ PlaneSlicerRasterPlannerWidget::PlaneSlicerRasterPlannerWidget(boost_plugin_load
   collapsible_area->setWidget(widget);
 
   ui_->group_box_raster_planner->layout()->addWidget(collapsible_area);
+}
+
+void PlaneSlicerRasterPlannerWidget::fromYAML(const YAML::Node& config)
+{
+  RasterPlannerWidget::fromYAML(config);
+  search_radius_->setValue(getEntry<double>(config, "search_radius"));
+  min_segment_size_->setValue(getEntry<double>(config, "min_segment_size"));
 }
 
 ToolPathPlanner::ConstPtr PlaneSlicerRasterPlannerWidget::create() const

--- a/noether_gui/src/widgets/raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/raster_planner_widget.cpp
@@ -8,7 +8,11 @@
 
 namespace noether
 {
-RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent)
+RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
+                                         QWidget* parent,
+                                         const double line_spacing,
+                                         const double point_spacing,
+                                         const double min_hole_size)
   : ToolPathPlannerWidget(parent), loader_(std::move(loader)), ui_(new Ui::RasterPlanner())
 {
   ui_->setupUi(this);
@@ -16,6 +20,10 @@ RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loa
   // Populate the combo boxes
   ui_->combo_box_dir_gen->addItems(getAvailablePlugins<DirectionGeneratorWidgetPlugin>(loader_));
   ui_->combo_box_origin_gen->addItems(getAvailablePlugins<OriginGeneratorWidgetPlugin>(loader_));
+
+  ui_->double_spin_box_line_spacing->setValue(line_spacing);
+  ui_->double_spin_box_point_spacing->setValue(point_spacing);
+  ui_->double_spin_box_minimum_hole_size->setValue(min_hole_size);
 
   connect(ui_->combo_box_dir_gen, &QComboBox::currentTextChanged, [this](const QString& text) {
     if (text.isEmpty())

--- a/noether_gui/src/widgets/raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/raster_planner_widget.cpp
@@ -90,7 +90,7 @@ void RasterPlannerWidget::configure(const YAML::Node& config)
   // Direction generator
   try
   {
-    auto dir_gen_config = getEntry<YAML::Node>(config, DIRECTION_GENERATOR_KEY);
+    const YAML::Node dir_gen_config = config[DIRECTION_GENERATOR_KEY];
     QString plugin_name = QString::fromStdString(getEntry<std::string>(dir_gen_config, "name"));
     setDirectionGeneratorWidget(plugin_name, dir_gen_config);
     ui_->group_box_dir_gen->setTitle(plugin_name);
@@ -103,7 +103,7 @@ void RasterPlannerWidget::configure(const YAML::Node& config)
   // Origin generator
   try
   {
-    auto origin_gen_config = getEntry<YAML::Node>(config, ORIGIN_GENERATOR_KEY);
+    const YAML::Node origin_gen_config = config[ORIGIN_GENERATOR_KEY];
     QString plugin_name = QString::fromStdString(getEntry<std::string>(origin_gen_config, "name"));
     setOriginGeneratorWidget(plugin_name, origin_gen_config);
     ui_->group_box_origin_gen->setTitle(plugin_name);

--- a/noether_gui/src/widgets/raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/raster_planner_widget.cpp
@@ -97,6 +97,21 @@ void RasterPlannerWidget::configure(const YAML::Node& config)
   }
 }
 
+void RasterPlannerWidget::save(YAML::Node& config) const
+{
+  YAML::Node dir_gen_config;
+  getDirectionGeneratorWidget()->save(dir_gen_config);
+  config["direction_generator"] = dir_gen_config;
+
+  YAML::Node origin_gen_config;
+  getOriginGeneratorWidget()->save(origin_gen_config);
+  config["origin_generator"] = origin_gen_config;
+
+  config["line_spacing"] = ui_->double_spin_box_line_spacing->value();
+  config["point_spacing"] = ui_->double_spin_box_point_spacing->value();
+  config["min_hole_size"] = ui_->double_spin_box_minimum_hole_size->value();
+}
+
 DirectionGeneratorWidget* RasterPlannerWidget::getDirectionGeneratorWidget() const
 {
   auto collapsible_area = dynamic_cast<CollapsibleArea*>(ui_->widget_dir_gen);

--- a/noether_gui/src/widgets/raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/raster_planner_widget.cpp
@@ -67,7 +67,7 @@ void RasterPlannerWidget::setOriginGeneratorWidget(const QString& plugin_name, c
   }
 }
 
-void RasterPlannerWidget::fromYAML(const YAML::Node& config)
+void RasterPlannerWidget::configure(const YAML::Node& config)
 {
   ui_->double_spin_box_line_spacing->setValue(getEntry<double>(config, "line_spacing"));
   ui_->double_spin_box_point_spacing->setValue(getEntry<double>(config, "point_spacing"));

--- a/noether_gui/src/widgets/raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/raster_planner_widget.cpp
@@ -93,7 +93,7 @@ void RasterPlannerWidget::configure(const YAML::Node& config)
   }
   catch (const std::exception& ex)
   {
-    QMessageBox::warning(this, "Direction generator configuration error", ex.what());
+    QMessageBox::warning(this, "Direction Generator Error", ex.what());
   }
 
   try
@@ -106,7 +106,7 @@ void RasterPlannerWidget::configure(const YAML::Node& config)
   }
   catch (const std::exception& ex)
   {
-    QMessageBox::warning(this, "Origin generator configuration error", ex.what());
+    QMessageBox::warning(this, "Origin Generator Error", ex.what());
   }
 }
 

--- a/noether_gui/src/widgets/raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/raster_planner_widget.cpp
@@ -5,14 +5,11 @@
 #include <noether_gui/utils.h>
 
 #include <QMessageBox>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
-RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader,
-                                         QWidget* parent,
-                                         const double line_spacing,
-                                         const double point_spacing,
-                                         const double min_hole_size)
+RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loader, QWidget* parent)
   : ToolPathPlannerWidget(parent), loader_(std::move(loader)), ui_(new Ui::RasterPlanner())
 {
   ui_->setupUi(this);
@@ -20,10 +17,6 @@ RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loa
   // Populate the combo boxes
   ui_->combo_box_dir_gen->addItems(getAvailablePlugins<DirectionGeneratorWidgetPlugin>(loader_));
   ui_->combo_box_origin_gen->addItems(getAvailablePlugins<OriginGeneratorWidgetPlugin>(loader_));
-
-  ui_->double_spin_box_line_spacing->setValue(line_spacing);
-  ui_->double_spin_box_point_spacing->setValue(point_spacing);
-  ui_->double_spin_box_minimum_hole_size->setValue(min_hole_size);
 
   connect(ui_->combo_box_dir_gen, &QComboBox::currentTextChanged, [this](const QString& text) {
     if (text.isEmpty())
@@ -70,6 +63,13 @@ RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loa
       }
     }
   });
+}
+
+void RasterPlannerWidget::fromYAML(const YAML::Node& config)
+{
+  ui_->double_spin_box_line_spacing->setValue(getEntry<double>(config, "line_spacing"));
+  ui_->double_spin_box_point_spacing->setValue(getEntry<double>(config, "point_spacing"));
+  ui_->double_spin_box_minimum_hole_size->setValue(getEntry<double>(config, "min_hole_size"));
 }
 
 DirectionGeneratorWidget* RasterPlannerWidget::getDirectionGeneratorWidget() const

--- a/noether_gui/src/widgets/raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/raster_planner_widget.cpp
@@ -25,56 +25,60 @@ RasterPlannerWidget::RasterPlannerWidget(boost_plugin_loader::PluginLoader&& loa
   ui_->combo_box_origin_gen->addItems(getAvailablePlugins<OriginGeneratorWidgetPlugin>(loader_));
 
   connect(ui_->push_button_dir_gen, &QPushButton::clicked, [this](const bool /*clicked*/) {
-    QString text = ui_->combo_box_dir_gen->currentText();
-    ui_->group_box_dir_gen->setTitle(text);
-    if (text.isEmpty())
-      overwriteWidget(ui_->group_box_dir_gen->layout(), ui_->widget_dir_gen, new QWidget(this));
-    else
-      setDirectionGeneratorWidget(text, {});
+    try
+    {
+      QString text = ui_->combo_box_dir_gen->currentText();
+      ui_->group_box_dir_gen->setTitle(text);
+      if (text.isEmpty())
+        overwriteWidget(ui_->group_box_dir_gen->layout(), ui_->widget_dir_gen, new QWidget(this));
+      else
+        setDirectionGeneratorWidget(text, {});
+    }
+    catch (const std::exception& ex)
+    {
+      std::stringstream ss;
+      printException(ex, ss);
+      QMessageBox::warning(this, "Configuration Error", QString::fromStdString(ss.str()));
+    }
   });
 
   connect(ui_->push_button_origin_gen, &QPushButton::clicked, [this](const bool /*clicked*/) {
-    QString text = ui_->combo_box_origin_gen->currentText();
-    ui_->group_box_origin_gen->setTitle(text);
-    if (text.isEmpty())
-      overwriteWidget(ui_->group_box_origin_gen->layout(), ui_->widget_origin_gen, new QWidget(this));
-    else
-      setOriginGeneratorWidget(text, {});
+    try
+    {
+      QString text = ui_->combo_box_origin_gen->currentText();
+      ui_->group_box_origin_gen->setTitle(text);
+      if (text.isEmpty())
+        overwriteWidget(ui_->group_box_origin_gen->layout(), ui_->widget_origin_gen, new QWidget(this));
+      else
+        setOriginGeneratorWidget(text, {});
+    }
+    catch (const std::exception& ex)
+    {
+      std::stringstream ss;
+      printException(ex, ss);
+      QMessageBox::warning(this, "Configuration Error", QString::fromStdString(ss.str()));
+    }
   });
 }
 
 void RasterPlannerWidget::setDirectionGeneratorWidget(const QString& plugin_name, const YAML::Node& config)
 {
-  try
-  {
-    auto plugin = loader_.createInstance<DirectionGeneratorWidgetPlugin>(plugin_name.toStdString());
+  auto plugin = loader_.createInstance<DirectionGeneratorWidgetPlugin>(plugin_name.toStdString());
 
-    auto collapsible_area = new CollapsibleArea(plugin_name, this);
-    collapsible_area->setWidget(plugin->create(this, config));
+  auto collapsible_area = new CollapsibleArea(plugin_name, this);
+  collapsible_area->setWidget(plugin->create(this, config));
 
-    overwriteWidget(ui_->group_box_dir_gen->layout(), ui_->widget_dir_gen, collapsible_area);
-  }
-  catch (const std::exception& ex)
-  {
-    QMessageBox::warning(this, "Direction Generator Error", QString::fromStdString(ex.what()));
-  }
+  overwriteWidget(ui_->group_box_dir_gen->layout(), ui_->widget_dir_gen, collapsible_area);
 }
 
 void RasterPlannerWidget::setOriginGeneratorWidget(const QString& plugin_name, const YAML::Node& config)
 {
-  try
-  {
-    auto plugin = loader_.createInstance<OriginGeneratorWidgetPlugin>(plugin_name.toStdString());
+  auto plugin = loader_.createInstance<OriginGeneratorWidgetPlugin>(plugin_name.toStdString());
 
-    auto collapsible_area = new CollapsibleArea(plugin_name, this);
-    collapsible_area->setWidget(plugin->create(this, config));
+  auto collapsible_area = new CollapsibleArea(plugin_name, this);
+  collapsible_area->setWidget(plugin->create(this, config));
 
-    overwriteWidget(ui_->group_box_origin_gen->layout(), ui_->widget_origin_gen, collapsible_area);
-  }
-  catch (const std::exception& ex)
-  {
-    QMessageBox::warning(this, "Origin Generator Error", QString::fromStdString(ex.what()));
-  }
+  overwriteWidget(ui_->group_box_origin_gen->layout(), ui_->widget_origin_gen, collapsible_area);
 }
 
 void RasterPlannerWidget::configure(const YAML::Node& config)
@@ -83,57 +87,49 @@ void RasterPlannerWidget::configure(const YAML::Node& config)
   ui_->double_spin_box_point_spacing->setValue(getEntry<double>(config, POINT_SPACING_KEY));
   ui_->double_spin_box_minimum_hole_size->setValue(getEntry<double>(config, MIN_HOLE_SIZE_KEY));
 
+  // Direction generator
   try
   {
-    // Direction generator
     auto dir_gen_config = getEntry<YAML::Node>(config, DIRECTION_GENERATOR_KEY);
     QString plugin_name = QString::fromStdString(getEntry<std::string>(dir_gen_config, "name"));
     setDirectionGeneratorWidget(plugin_name, dir_gen_config);
     ui_->group_box_dir_gen->setTitle(plugin_name);
   }
-  catch (const std::exception& ex)
+  catch (const std::exception&)
   {
-    QMessageBox::warning(this, "Direction Generator Error", ex.what());
+    std::throw_with_nested(std::runtime_error("Error configuring direction generator: "));
   }
 
+  // Origin generator
   try
   {
-    // Origin generator
     auto origin_gen_config = getEntry<YAML::Node>(config, ORIGIN_GENERATOR_KEY);
     QString plugin_name = QString::fromStdString(getEntry<std::string>(origin_gen_config, "name"));
     setOriginGeneratorWidget(plugin_name, origin_gen_config);
     ui_->group_box_origin_gen->setTitle(plugin_name);
   }
-  catch (const std::exception& ex)
+  catch (const std::exception&)
   {
-    QMessageBox::warning(this, "Origin Generator Error", ex.what());
+    std::throw_with_nested(std::runtime_error("Error configuring origin generator: "));
   }
 }
 
 void RasterPlannerWidget::save(YAML::Node& config) const
 {
   // Direction generator
-  try
   {
     YAML::Node dir_gen_config;
     dir_gen_config["name"] = ui_->group_box_dir_gen->title().toStdString();
     getDirectionGeneratorWidget()->save(dir_gen_config);
     config[DIRECTION_GENERATOR_KEY] = dir_gen_config;
   }
-  catch (const std::exception&)
-  {
-  }
 
   // Origin generator
-  try
   {
     YAML::Node origin_gen_config;
     origin_gen_config["name"] = ui_->group_box_origin_gen->title().toStdString();
     getOriginGeneratorWidget()->save(origin_gen_config);
     config[ORIGIN_GENERATOR_KEY] = origin_gen_config;
-  }
-  catch (const std::exception&)
-  {
   }
 
   config[LINE_SPACING_KEY] = ui_->double_spin_box_line_spacing->value();

--- a/noether_gui/src/widgets/tool_path_modifier_widgets.cpp
+++ b/noether_gui/src/widgets/tool_path_modifier_widgets.cpp
@@ -1,11 +1,13 @@
 #include <noether_gui/widgets/tool_path_modifier_widgets.h>
 #include "ui_vector3d_editor_widget.h"
+#include <noether_gui/utils.h>
 
 #include <noether_tpp/tool_path_modifiers/organization_modifiers.h>
 #include <noether_tpp/tool_path_modifiers/waypoint_orientation_modifiers.h>
 #include <QFormLayout>
 #include <QLabel>
 #include <QSpinBox>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
@@ -14,6 +16,13 @@ StandardEdgePathsOrganizationModifierWidget::StandardEdgePathsOrganizationModifi
 {
   ui_->setupUi(this);
   ui_->group_box->setTitle("Start Reference");
+}
+
+void StandardEdgePathsOrganizationModifierWidget::fromYAML(const YAML::Node& config)
+{
+  ui_->double_spin_box_x->setValue(getEntry<double>(config, "x"));
+  ui_->double_spin_box_y->setValue(getEntry<double>(config, "y"));
+  ui_->double_spin_box_z->setValue(getEntry<double>(config, "z"));
 }
 
 ToolPathModifier::ConstPtr StandardEdgePathsOrganizationModifierWidget::create() const
@@ -43,6 +52,16 @@ FixedOrientationModifierWidget::FixedOrientationModifierWidget(QWidget* parent)
   ui_->double_spin_box_x->setValue(1.0);
 }
 
+void FixedOrientationModifierWidget::fromYAML(const YAML::Node& config)
+{
+  Eigen::Vector3d dir(getEntry<double>(config, "x"), getEntry<double>(config, "y"), getEntry<double>(config, "z"));
+  dir.normalize();
+
+  ui_->double_spin_box_x->setValue(dir.x());
+  ui_->double_spin_box_y->setValue(dir.y());
+  ui_->double_spin_box_z->setValue(dir.z());
+}
+
 ToolPathModifier::ConstPtr FixedOrientationModifierWidget::create() const
 {
   Eigen::Vector3d ref_x_dir(
@@ -69,6 +88,11 @@ MovingAverageOrientationSmoothingModifierWidget::MovingAverageOrientationSmoothi
 {
   layout_->addRow(label_, window_size_);
   window_size_->setMinimum(3);
+}
+
+void MovingAverageOrientationSmoothingModifierWidget::fromYAML(const YAML::Node& config)
+{
+  window_size_->setValue(getEntry<int>(config, "window_size"));
 }
 
 ToolPathModifier::ConstPtr MovingAverageOrientationSmoothingModifierWidget::create() const

--- a/noether_gui/src/widgets/tool_path_modifier_widgets.cpp
+++ b/noether_gui/src/widgets/tool_path_modifier_widgets.cpp
@@ -25,6 +25,13 @@ void StandardEdgePathsOrganizationModifierWidget::configure(const YAML::Node& co
   ui_->double_spin_box_z->setValue(getEntry<double>(config, "z"));
 }
 
+void StandardEdgePathsOrganizationModifierWidget::save(YAML::Node& config) const
+{
+  config["x"] = ui_->double_spin_box_x->value();
+  config["y"] = ui_->double_spin_box_y->value();
+  config["z"] = ui_->double_spin_box_z->value();
+}
+
 ToolPathModifier::ConstPtr StandardEdgePathsOrganizationModifierWidget::create() const
 {
   Eigen::Vector3d start_ref(
@@ -62,6 +69,13 @@ void FixedOrientationModifierWidget::configure(const YAML::Node& config)
   ui_->double_spin_box_z->setValue(dir.z());
 }
 
+void FixedOrientationModifierWidget::save(YAML::Node& config) const
+{
+  config["x"] = ui_->double_spin_box_x->value();
+  config["y"] = ui_->double_spin_box_y->value();
+  config["z"] = ui_->double_spin_box_z->value();
+}
+
 ToolPathModifier::ConstPtr FixedOrientationModifierWidget::create() const
 {
   Eigen::Vector3d ref_x_dir(
@@ -93,6 +107,11 @@ MovingAverageOrientationSmoothingModifierWidget::MovingAverageOrientationSmoothi
 void MovingAverageOrientationSmoothingModifierWidget::configure(const YAML::Node& config)
 {
   window_size_->setValue(getEntry<int>(config, "window_size"));
+}
+
+void MovingAverageOrientationSmoothingModifierWidget::save(YAML::Node& config) const
+{
+  config["window_size"] = window_size_->value();
 }
 
 ToolPathModifier::ConstPtr MovingAverageOrientationSmoothingModifierWidget::create() const

--- a/noether_gui/src/widgets/tool_path_modifier_widgets.cpp
+++ b/noether_gui/src/widgets/tool_path_modifier_widgets.cpp
@@ -18,7 +18,7 @@ StandardEdgePathsOrganizationModifierWidget::StandardEdgePathsOrganizationModifi
   ui_->group_box->setTitle("Start Reference");
 }
 
-void StandardEdgePathsOrganizationModifierWidget::fromYAML(const YAML::Node& config)
+void StandardEdgePathsOrganizationModifierWidget::configure(const YAML::Node& config)
 {
   ui_->double_spin_box_x->setValue(getEntry<double>(config, "x"));
   ui_->double_spin_box_y->setValue(getEntry<double>(config, "y"));
@@ -52,7 +52,7 @@ FixedOrientationModifierWidget::FixedOrientationModifierWidget(QWidget* parent)
   ui_->double_spin_box_x->setValue(1.0);
 }
 
-void FixedOrientationModifierWidget::fromYAML(const YAML::Node& config)
+void FixedOrientationModifierWidget::configure(const YAML::Node& config)
 {
   Eigen::Vector3d dir(getEntry<double>(config, "x"), getEntry<double>(config, "y"), getEntry<double>(config, "z"));
   dir.normalize();
@@ -90,7 +90,7 @@ MovingAverageOrientationSmoothingModifierWidget::MovingAverageOrientationSmoothi
   window_size_->setMinimum(3);
 }
 
-void MovingAverageOrientationSmoothingModifierWidget::fromYAML(const YAML::Node& config)
+void MovingAverageOrientationSmoothingModifierWidget::configure(const YAML::Node& config)
 {
   window_size_->setValue(getEntry<int>(config, "window_size"));
 }

--- a/noether_gui/src/widgets/tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/tpp_pipeline_widget.cpp
@@ -90,11 +90,11 @@ void TPPPipelineWidget::configure(const YAML::Node& config)
   try
   {
     // Mesh modifier
-    mesh_modifier_loader_widget_->configure(getEntry<YAML::Node>(config, MESH_MODIFIERS_KEY));
+    mesh_modifier_loader_widget_->configure(config[MESH_MODIFIERS_KEY]);
 
     // Tool path planner
     {
-      auto tpp_config = getEntry<YAML::Node>(config, TOOL_PATH_PLANNER_KEY);
+      auto tpp_config = config[TOOL_PATH_PLANNER_KEY];
       auto name = getEntry<std::string>(tpp_config, "name");
       auto plugin = loader_.createInstance<ToolPathPlannerWidgetPlugin>(name);
       overwriteWidget(ui_->group_box_tpp->layout(), ui_->widget_tpp, plugin->create(this, tpp_config));
@@ -102,7 +102,7 @@ void TPPPipelineWidget::configure(const YAML::Node& config)
     }
 
     // Tool path modifiers
-    tool_path_modifier_loader_widget_->configure(getEntry<YAML::Node>(config, TOOL_PATH_MODIFIERS_KEY));
+    tool_path_modifier_loader_widget_->configure(config[TOOL_PATH_MODIFIERS_KEY]);
   }
   catch (const std::exception&)
   {

--- a/noether_gui/src/widgets/tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/tpp_pipeline_widget.cpp
@@ -93,12 +93,17 @@ void TPPPipelineWidget::configure(const YAML::Node& config)
     mesh_modifier_loader_widget_->configure(config[MESH_MODIFIERS_KEY]);
 
     // Tool path planner
+    try
     {
       auto tpp_config = config[TOOL_PATH_PLANNER_KEY];
       auto name = getEntry<std::string>(tpp_config, "name");
       auto plugin = loader_.createInstance<ToolPathPlannerWidgetPlugin>(name);
       overwriteWidget(ui_->group_box_tpp->layout(), ui_->widget_tpp, plugin->create(this, tpp_config));
       ui_->group_box_tpp->setTitle(QString::fromStdString(name));
+    }
+    catch (const std::exception&)
+    {
+      std::throw_with_nested(std::runtime_error("Error configuring tool path planner: "));
     }
 
     // Tool path modifiers

--- a/noether_gui/src/widgets/tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/tpp_pipeline_widget.cpp
@@ -48,10 +48,18 @@ TPPPipelineWidget::TPPPipelineWidget(boost_plugin_loader::PluginLoader loader, Q
   ui_->combo_box_tpp->addItems(getAvailablePlugins<ToolPathPlannerWidgetPlugin>(loader_));
 
   // Add the tool path modifier loader widget
-  ui_->vertical_layout_tool_path_mod->addWidget(tool_path_modifier_loader_widget_);
+  {
+    auto layout = new QVBoxLayout();
+    layout->addWidget(tool_path_modifier_loader_widget_);
+    ui_->tab_tool_path_modifier->setLayout(layout);
+  }
 
   // Add the mesh modifier loader widget
-  ui_->vertical_layout_mesh_mod->addWidget(mesh_modifier_loader_widget_);
+  {
+    auto layout = new QVBoxLayout();
+    layout->addWidget(mesh_modifier_loader_widget_);
+    ui_->tab_mesh_modifier->setLayout(layout);
+  }
 
   connect(ui_->push_button_select_tpp, &QPushButton::clicked, [this](const bool /*checked*/) {
     const QString text = ui_->combo_box_tpp->currentText();

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -3,22 +3,26 @@
 #include <noether_gui/widgets/tpp_pipeline_widget.h>
 #include <noether_gui/utils.h>
 
+#include <fstream>
 #include <pcl/io/vtk_lib_io.h>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QStandardPaths>
 #include <QTextStream>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
-TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent) : QWidget(parent), ui_(new Ui::TPP())
+TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
+  : QWidget(parent), ui_(new Ui::TPP()), pipeline_widget_(new TPPPipelineWidget(std::move(loader), this))
 {
   ui_->setupUi(this);
 
-  auto pipeline = new TPPPipelineWidget(std::move(loader), this);
-  ui_->scroll_area->setWidget(pipeline);
+  ui_->scroll_area->setWidget(pipeline_widget_);
 
   connect(ui_->push_button_load_mesh, &QPushButton::clicked, this, &TPPWidget::onLoadMesh);
+  connect(ui_->push_button_load_configuration, &QPushButton::clicked, this, &TPPWidget::onLoadConfiguration);
+  connect(ui_->push_button_save_configuration, &QPushButton::clicked, this, &TPPWidget::onSaveConfiguration);
   connect(ui_->push_button_plan, &QPushButton::clicked, this, &TPPWidget::onPlan);
 }
 
@@ -31,14 +35,68 @@ void TPPWidget::onLoadMesh(const bool /*checked*/)
   ui_->line_edit_mesh->setText(file);
 }
 
+void TPPWidget::onLoadConfiguration(const bool /*checked*/)
+{
+  QString file = ui_->line_edit_configuration->text();
+  if (file.isEmpty())
+    file = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
+
+  file = QFileDialog::getOpenFileName(this, "Load configuration file", file, "YAML files (*.yaml)");
+  if (file.isEmpty())
+    return;
+
+  ui_->line_edit_configuration->setText(file);
+
+  try
+  {
+    pipeline_widget_->configure(YAML::LoadFile(file.toStdString()));
+    QMessageBox::information(this, "Configuration", "Successfully loaded tool path planning pipeline configuration");
+  }
+  catch (const YAML::BadFile& ex)
+  {
+    QString message;
+    QTextStream ss(&message);
+    ss << "Failed to open YAML file at '" << file << "'";
+    QMessageBox::warning(this, "Configuration Error", message);
+  }
+  catch (const std::exception& ex)
+  {
+    QMessageBox::warning(this, "Configuration Error", ex.what());
+  }
+}
+
+void TPPWidget::onSaveConfiguration(const bool /*checked*/)
+{
+  QString file = ui_->line_edit_configuration->text();
+  if (file.isEmpty())
+    file = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
+
+  file = QFileDialog::getSaveFileName(this, "Save configuration file", file, "YAML files (*.yaml)");
+  if (file.isEmpty())
+    return;
+
+  YAML::Node config;
+  pipeline_widget_->save(config);
+
+  std::ofstream ofh(file.toStdString());
+  if (!ofh)
+  {
+    QString message;
+    QTextStream ss(&message);
+    ss << "Failed to open output file at '" << file << "'";
+    QMessageBox::warning(this, "Error", message);
+  }
+  else
+  {
+    ofh << config;
+    QMessageBox::information(this, "Configuration", "Successfully saved tool path planning pipeline configuration");
+  }
+}
+
 void TPPWidget::onPlan(const bool /*checked*/)
 {
   try
   {
-    auto pipeline_widget = dynamic_cast<TPPPipelineWidget*>(ui_->scroll_area->widget());
-    if (!pipeline_widget)
-      throw std::runtime_error("Tool path planning pipeline widget is not configured correctly");
-
     const std::string mesh_file = ui_->line_edit_mesh->text().toStdString();
     if (mesh_file.empty())
       throw std::runtime_error("No mesh file selected");
@@ -48,7 +106,7 @@ void TPPWidget::onPlan(const bool /*checked*/)
     if (pcl::io::loadPolygonFile(mesh_file, mesh) < 1)
       throw std::runtime_error("Failed to load mesh from file");
 
-    const ToolPathPlannerPipeline pipeline = pipeline_widget->createPipeline();
+    const ToolPathPlannerPipeline pipeline = pipeline_widget_->createPipeline();
     QApplication::setOverrideCursor(Qt::WaitCursor);
     tool_paths_ = pipeline.plan(mesh);
     QApplication::restoreOverrideCursor();

--- a/noether_gui/ui/plugin_loader_widget.ui
+++ b/noether_gui/ui/plugin_loader_widget.ui
@@ -52,6 +52,19 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/noether_gui/ui/raster_planner_widget.ui
+++ b/noether_gui/ui/raster_planner_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>363</width>
-    <height>352</height>
+    <width>420</width>
+    <height>401</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <widget class="QGroupBox" name="group_box_dir_gen">
+    <widget class="QGroupBox" name="group_box_dir_gen_container">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -27,16 +27,36 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QComboBox" name="combo_box_dir_gen"/>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QComboBox" name="combo_box_dir_gen"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="push_button_dir_gen">
+          <property name="text">
+           <string>Select</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QWidget" name="widget_dir_gen" native="true"/>
+       <widget class="QGroupBox" name="group_box_dir_gen">
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QWidget" name="widget_dir_gen" native="true"/>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="group_box_origin_gen">
+    <widget class="QGroupBox" name="group_box_origin_gen_container">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -46,12 +66,32 @@
      <property name="title">
       <string>Origin Generator</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
-       <widget class="QComboBox" name="combo_box_origin_gen"/>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QComboBox" name="combo_box_origin_gen"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="push_button_origin_gen">
+          <property name="text">
+           <string>Select</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QWidget" name="widget_origin_gen" native="true"/>
+       <widget class="QGroupBox" name="group_box_origin_gen">
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <widget class="QWidget" name="widget_origin_gen" native="true"/>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/noether_gui/ui/raster_planner_widget.ui
+++ b/noether_gui/ui/raster_planner_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>420</width>
-    <height>401</height>
+    <width>413</width>
+    <height>373</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,85 +15,90 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <widget class="QGroupBox" name="group_box_dir_gen_container">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="title">
-      <string>Direction Generator</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QComboBox" name="combo_box_dir_gen"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="push_button_dir_gen">
-          <property name="text">
-           <string>Select</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="group_box_dir_gen">
-        <property name="title">
-         <string/>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
+     <widget class="QWidget" name="tab_direction_generator">
+      <attribute name="title">
+       <string>Direction Generator</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QWidget" name="widget_dir_gen" native="true"/>
+          <widget class="QComboBox" name="combo_box_dir_gen"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="push_button_dir_gen">
+           <property name="text">
+            <string>Select</string>
+           </property>
+          </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="group_box_origin_gen_container">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Origin Generator</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_5">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QComboBox" name="combo_box_origin_gen"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="push_button_origin_gen">
-          <property name="text">
-           <string>Select</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="group_box_origin_gen">
-        <property name="title">
-         <string/>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_6">
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="group_box_dir_gen">
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QWidget" name="widget_dir_gen" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_origin_generator">
+      <attribute name="title">
+       <string>Origin Generator</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QWidget" name="widget_origin_gen" native="true"/>
+          <widget class="QComboBox" name="combo_box_origin_gen"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="push_button_origin_gen">
+           <property name="text">
+            <string>Select</string>
+           </property>
+          </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="group_box_origin_gen">
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <widget class="QWidget" name="widget_origin_gen" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/noether_gui/ui/tpp_pipeline_widget.ui
+++ b/noether_gui/ui/tpp_pipeline_widget.ui
@@ -24,7 +24,7 @@
     <layout class="QVBoxLayout" name="vertical_layout_mesh_mod"/>
    </item>
    <item>
-    <widget class="QGroupBox" name="group_box_tpp">
+    <widget class="QGroupBox" name="group_box_tpp_container">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -36,10 +36,30 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QComboBox" name="combo_box_tpp"/>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QComboBox" name="combo_box_tpp"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="push_button_select_tpp">
+          <property name="text">
+           <string>Select</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
-       <widget class="QWidget" name="widget_tpp" native="true"/>
+       <widget class="QGroupBox" name="group_box_tpp">
+        <property name="title">
+         <string/>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QWidget" name="widget_tpp" native="true"/>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/noether_gui/ui/tpp_pipeline_widget.ui
+++ b/noether_gui/ui/tpp_pipeline_widget.ui
@@ -19,66 +19,63 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <layout class="QVBoxLayout" name="vertical_layout_mesh_mod"/>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="group_box_tpp_container">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <property name="title">
-      <string>Tool Path Planner</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QComboBox" name="combo_box_tpp"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="push_button_select_tpp">
-          <property name="text">
-           <string>Select</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="group_box_tpp">
-        <property name="title">
-         <string/>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+     <widget class="QWidget" name="tab_mesh_modifier">
+      <attribute name="title">
+       <string>Mesh Modifier</string>
+      </attribute>
+     </widget>
+     <widget class="QWidget" name="tab_tool_path_planner">
+      <attribute name="title">
+       <string>Tool Path Planner</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <widget class="QWidget" name="widget_tpp" native="true"/>
+          <widget class="QComboBox" name="combo_box_tpp"/>
+         </item>
+         <item>
+          <widget class="QPushButton" name="push_button_select_tpp">
+           <property name="text">
+            <string>Select</string>
+           </property>
+          </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-     </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="group_box_tpp">
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QWidget" name="widget_tpp" native="true"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_tool_path_modifier">
+      <attribute name="title">
+       <string>Tool Path Modifier</string>
+      </attribute>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="vertical_layout_tool_path_mod"/>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/noether_gui/ui/tpp_widget.ui
+++ b/noether_gui/ui/tpp_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>551</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,6 +44,40 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="group_box_configuration">
+     <property name="title">
+      <string>Configuration</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLineEdit" name="line_edit_configuration">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="push_button_load_configuration">
+          <property name="text">
+           <string>Load</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QPushButton" name="push_button_save_configuration">
+        <property name="text">
+         <string>Save</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QScrollArea" name="scroll_area">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
@@ -69,7 +103,7 @@
         <x>0</x>
         <y>0</y>
         <width>380</width>
-        <height>174</height>
+        <height>335</height>
        </rect>
       </property>
      </widget>
@@ -84,6 +118,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>line_edit_mesh</tabstop>
+  <tabstop>push_button_load_mesh</tabstop>
+  <tabstop>line_edit_configuration</tabstop>
+  <tabstop>push_button_load_configuration</tabstop>
+  <tabstop>push_button_save_configuration</tabstop>
+  <tabstop>scroll_area</tabstop>
+  <tabstop>push_button_plan</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR adds the ability to load and save the tool path configuration from the GUI to a YAML file. It also updates the design of the tool path planner pipeline GUI to utilize tab widgets for the pipeline components and raster planner component to make the display a little more compact

## Nominal GUI
![image](https://user-images.githubusercontent.com/18411310/236310743-71b55f4b-72c2-4801-bc69-fcb6fabdd28e.png)

## Configured GUI
![image](https://user-images.githubusercontent.com/18411310/236311044-65fb110a-454a-4dec-a663-51bc71e98d63.png)

## Sample YAML file
```yaml
mesh_modifiers: ~
tool_path_planner:
  name: PlaneSlicerRasterPlanner
  direction_generator:
    name: PrincipalAxisDirectionGenerator
    rotation_offset: 90
  origin_generator:
    name: FixedOriginGenerator
    x: 0.1
    y: 0.1
    z: 0.1
  line_spacing: 0.2
  point_spacing: 0.2
  min_hole_size: 0.2
  search_radius: 0.2
  min_segment_size: 0.2
tool_path_modifiers:
  - name: DirectionOfTravelOrientationModifier
  - name: MovingAverageOrientationSmoothingModifier
    window_size: 7
  - name: StandardEdgePathsOrganizationModifier
    x: 1
    y: 2
    z: 3
  - name: UniformOrientationModifier
  - name: SnakeOrganizationModifier
  - name: RasterOrganizationModifier
  - name: FixedOrientationModifier
    x: 1
    y: 1
    z: 2
```
