### PR TITLE
Fixed build issue with missing yaml-cpp include

### DIFF
--- a/noether_gui/include/noether_gui/widgets.h
+++ b/noether_gui/include/noether_gui/widgets.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+#include <yaml-cpp/yaml.h>
 
 namespace YAML
 {


### PR DESCRIPTION
Weirdly this isn't causing any problems in my ROS build, but my ROS 2 build fails without this include. Regardless it makes sense to me that this should be included.