### PR TITLE
Feature/straight lead in toolpath

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -41,7 +41,7 @@ qt5_wrap_cpp(${PROJECT_NAME}_widget_mocs
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/raster_organization_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/snake_organization_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/standard_edge_paths_organization_modifier_widget.h
-  include/${PROJECT_NAME}/widgets/tool_path_modifiers/straight_approach_modifier_widget.h
+  include/${PROJECT_NAME}/widgets/tool_path_modifiers/linear_approach_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/uniform_orientation_modifier_widget.h)
 
@@ -83,7 +83,7 @@ add_library(${PROJECT_NAME} SHARED
   src/widgets/tool_path_modifiers/raster_organization_modifier_widget.cpp
   src/widgets/tool_path_modifiers/snake_organization_modifier_widget.cpp
   src/widgets/tool_path_modifiers/standard_edge_paths_organization_modifier_widget.cpp
-  src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
+  src/widgets/tool_path_modifiers/linear_approach_modifier_widget.cpp
   src/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.cpp
   src/widgets/tool_path_modifiers/uniform_orientation_modifier_widget.cpp
   ${${PROJECT_NAME}_widget_mocs}

--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -41,6 +41,7 @@ qt5_wrap_cpp(${PROJECT_NAME}_widget_mocs
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/raster_organization_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/snake_organization_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/standard_edge_paths_organization_modifier_widget.h
+  include/${PROJECT_NAME}/widgets/tool_path_modifiers/straight_approach_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.h
   include/${PROJECT_NAME}/widgets/tool_path_modifiers/uniform_orientation_modifier_widget.h)
 
@@ -82,6 +83,7 @@ add_library(${PROJECT_NAME} SHARED
   src/widgets/tool_path_modifiers/raster_organization_modifier_widget.cpp
   src/widgets/tool_path_modifiers/snake_organization_modifier_widget.cpp
   src/widgets/tool_path_modifiers/standard_edge_paths_organization_modifier_widget.cpp
+  src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
   src/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.cpp
   src/widgets/tool_path_modifiers/uniform_orientation_modifier_widget.cpp
   ${${PROJECT_NAME}_widget_mocs}

--- a/noether_gui/include/noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h
@@ -8,11 +8,11 @@ class QSpinBox;
 
 namespace noether
 {
-class StraightApproachToolPathModifierWidget : public ToolPathModifierWidget
+class LinearApproachToolPathModifierWidget : public ToolPathModifierWidget
 {
   Q_OBJECT
 public:
-  StraightApproachToolPathModifierWidget(QWidget* parent = nullptr);
+  LinearApproachToolPathModifierWidget(QWidget* parent = nullptr);
 
   ToolPathModifier::ConstPtr create() const override;
 

--- a/noether_gui/include/noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h
@@ -3,7 +3,6 @@
 #include <noether_gui/widgets.h>
 #include <noether_tpp/core/tool_path_modifier.h>
 
-class QDoubleSpinBox;
 class QSpinBox;
 
 namespace Ui
@@ -25,7 +24,6 @@ public:
   void save(YAML::Node&) const override;
 
 private:
-//  QDoubleSpinBox* offset_;
   Ui::Vector3dEditor* ui_;
   QSpinBox* n_points_;
 };

--- a/noether_gui/include/noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h
@@ -6,6 +6,11 @@
 class QDoubleSpinBox;
 class QSpinBox;
 
+namespace Ui
+{
+class Vector3dEditor;
+}
+
 namespace noether
 {
 class LinearApproachToolPathModifierWidget : public ToolPathModifierWidget
@@ -20,7 +25,8 @@ public:
   void save(YAML::Node&) const override;
 
 private:
-  QDoubleSpinBox* offset_height_;
+//  QDoubleSpinBox* offset_;
+  Ui::Vector3dEditor* ui_;
   QSpinBox* n_points_;
 };
 

--- a/noether_gui/include/noether_gui/widgets/tool_path_modifiers/straight_approach_modifier_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_modifiers/straight_approach_modifier_widget.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <noether_gui/widgets.h>
+#include <noether_tpp/core/tool_path_modifier.h>
+
+class QDoubleSpinBox;
+class QSpinBox;
+
+namespace noether
+{
+class StraightApproachToolPathModifierWidget : public ToolPathModifierWidget
+{
+  Q_OBJECT
+public:
+  StraightApproachToolPathModifierWidget(QWidget* parent = nullptr);
+
+  ToolPathModifier::ConstPtr create() const override;
+
+  void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
+
+private:
+  QDoubleSpinBox* offset_height_;
+  QSpinBox* n_points_;
+};
+
+}  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -47,6 +47,7 @@ public:
   void setMeshFile(const QString& file);
   void setConfigurationFile(const QString& file);
 
+
 private:
   void onLoadMesh(const bool /*checked*/);
   void onLoadConfiguration(const bool /*checked*/);

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -22,7 +22,7 @@
 #include <noether_gui/widgets/tool_path_modifiers/standard_edge_paths_organization_modifier_widget.h>
 #include <noether_gui/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.h>
 #include <noether_gui/widgets/tool_path_modifiers/uniform_orientation_modifier_widget.h>
-#include <noether_gui/widgets/tool_path_modifiers/straight_approach_modifier_widget.h>
+#include <noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h>
 
 #include <QWidget>
 #include <QMessageBox>
@@ -88,8 +88,8 @@ using CircularLeadInToolPathModifierWidgetPlugin =
 using CircularLeadOutToolPathModifierWidgetPlugin =
     WidgetPluginImpl<CircularLeadOutToolPathModifierWidget, ToolPathModifierWidget>;
 
-using StraightApproachToolPathModifierWidgetPlugin =
-    WidgetPluginImpl<StraightApproachToolPathModifierWidget, ToolPathModifierWidget>;
+using LinearApproachToolPathModifierWidgetPlugin =
+    WidgetPluginImpl<LinearApproachToolPathModifierWidget, ToolPathModifierWidget>;
 
 // Raster Tool Path Planners
 struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
@@ -135,6 +135,6 @@ EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::ToolDragOrientationToolPathModi
                                         ToolDragOrientationToolPathModifier)
 EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::CircularLeadInToolPathModifierWidgetPlugin, CircularLeadInModifier)
 EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::CircularLeadOutToolPathModifierWidgetPlugin, CircularLeadOutModifier)
-EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::StraightApproachToolPathModifierWidgetPlugin, StraightApproachModifier)
+EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::LinearApproachToolPathModifierWidgetPlugin, LinearApproachModifier)
 
 EXPORT_TPP_WIDGET_PLUGIN(noether::PlaneSlicerRasterPlannerWidgetPlugin, PlaneSlicerRasterPlanner)

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -22,6 +22,7 @@
 #include <noether_gui/widgets/tool_path_modifiers/standard_edge_paths_organization_modifier_widget.h>
 #include <noether_gui/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.h>
 #include <noether_gui/widgets/tool_path_modifiers/uniform_orientation_modifier_widget.h>
+#include <noether_gui/widgets/tool_path_modifiers/straight_approach_modifier_widget.h>
 
 #include <QWidget>
 #include <QMessageBox>
@@ -87,6 +88,9 @@ using CircularLeadInToolPathModifierWidgetPlugin =
 using CircularLeadOutToolPathModifierWidgetPlugin =
     WidgetPluginImpl<CircularLeadOutToolPathModifierWidget, ToolPathModifierWidget>;
 
+using StraightApproachToolPathModifierWidgetPlugin =
+    WidgetPluginImpl<StraightApproachToolPathModifierWidget, ToolPathModifierWidget>;
+
 // Raster Tool Path Planners
 struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
 {
@@ -131,5 +135,6 @@ EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::ToolDragOrientationToolPathModi
                                         ToolDragOrientationToolPathModifier)
 EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::CircularLeadInToolPathModifierWidgetPlugin, CircularLeadInModifier)
 EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::CircularLeadOutToolPathModifierWidgetPlugin, CircularLeadOutModifier)
+EXPORT_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(noether::StraightApproachToolPathModifierWidgetPlugin, StraightApproachModifier)
 
 EXPORT_TPP_WIDGET_PLUGIN(noether::PlaneSlicerRasterPlannerWidgetPlugin, PlaneSlicerRasterPlanner)

--- a/noether_gui/src/widgets/tool_path_modifiers/linear_approach_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/linear_approach_modifier_widget.cpp
@@ -5,53 +5,110 @@
 #include <QFormLayout>
 #include <QLabel>
 #include <QDoubleSpinBox>
+#include "ui_vector3d_editor_widget.h"
 
-static const std::string OFFSET_HEIGHT_KEY = "offset_height";
+
+static const std::string OFFSET_KEY = "offset";
 static const std::string N_POINTS_KEY = "n_points";
 
 namespace noether
 {
 LinearApproachToolPathModifierWidget::LinearApproachToolPathModifierWidget(QWidget* parent)
-  : ToolPathModifierWidget(parent)
+  : ToolPathModifierWidget(parent), ui_(new Ui::Vector3dEditor())
 {
-  auto layout = new QFormLayout(this);
+//  auto layout = new QFormLayout(this);
+//  // Height Offset
+////  offset_ = new QDoubleSpinBox(this);
+////  offset_->setMinimum(0.0);
+////  offset_->setSingleStep(0.01);
+////  offset_->setValue(0.1);
+////  offset_->setDecimals(3);
+////  auto label_offset = new QLabel("Height offset (m)", this);
+////  label_offset->setToolTip("Distance from the first segment point to the first point of the approach trajectory");
+////  layout->addRow(label_offset, offset_);
+//  ui_->setupUi(this);
+//  ui_->group_box->setTitle("Offset (m)");
 
-  // Height Offset
-  offset_height_ = new QDoubleSpinBox(this);
-  offset_height_->setMinimum(0.0);
-  offset_height_->setSingleStep(0.01);
-  offset_height_->setValue(0.1);
-  offset_height_->setDecimals(3);
-  auto label_offset = new QLabel("Height offset (m)", this);
-  label_offset->setToolTip("Distance from the first segment point to the first point of the approach trajectory");
-  layout->addRow(label_offset, offset_height_);
+//  ui_->double_spin_box_z->setValue(0.1);
+
+//  // Number of points
+//  n_points_ = new QSpinBox(this);
+//  n_points_->setMinimum(0.0);
+//  n_points_->setSingleStep(1);
+//  n_points_->setValue(5);
+//  auto label_pnt = new QLabel("Lead in number of points", this);
+//  label_pnt->setToolTip("Number of waypoints along the approach trajectory");
+//  layout->addRow(label_pnt, n_points_);
+
+//  setLayout(layout);
+  // Create a vertical layout for the entire widget
+  auto mainLayout = new QVBoxLayout(this);
+
+  ui_->setupUi(this);
+  ui_->group_box->setTitle("Offset (m)");
+  ui_->double_spin_box_z->setValue(0.1);
+
+  // Create a container widget to hold the layouts
+  auto containerWidget = new QWidget;
+
+  // Create a layout for the container widget
+  auto containerLayout = new QVBoxLayout(containerWidget);
+
+  // Create a horizontal layout for the spin box and label
+  auto spinBoxLayout = new QHBoxLayout;
+
   // Number of points
   n_points_ = new QSpinBox(this);
-  n_points_->setMinimum(0.0);
+  n_points_->setMinimum(0);
   n_points_->setSingleStep(1);
   n_points_->setValue(5);
+
   auto label_pnt = new QLabel("Lead in number of points", this);
   label_pnt->setToolTip("Number of waypoints along the approach trajectory");
-  layout->addRow(label_pnt, n_points_);
 
-  setLayout(layout);
+  // Add label and spin box to the horizontal layout
+  spinBoxLayout->addWidget(label_pnt);
+  spinBoxLayout->addWidget(n_points_);
+
+  // Add the horizontal layout to the container layout
+  containerLayout->addLayout(spinBoxLayout);
+
+  // Set the container widget as the layout for the Vector3dEditor widget
+  ui_->group_box->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  containerLayout->addWidget(ui_->group_box);
+
+  // Add the container widget to the main layout
+  mainLayout->addWidget(containerWidget);
+
+  // Set the main layout for the entire widget
+  setLayout(mainLayout);
 }
 
 ToolPathModifier::ConstPtr LinearApproachToolPathModifierWidget::create() const
 {
-  return std::make_unique<LinearApproachModifier>(offset_height_->value(), n_points_->value());
+  Eigen::Vector3d dir(
+      ui_->double_spin_box_x->value(), ui_->double_spin_box_y->value(), ui_->double_spin_box_z->value());
+  return std::make_unique<LinearApproachModifier>(dir, n_points_->value());
 }
 
 
 void LinearApproachToolPathModifierWidget::configure(const YAML::Node& config)
 {
-  offset_height_->setValue(getEntry<double>(config, OFFSET_HEIGHT_KEY));
+//  offset_->setValue(getEntry<Eigen::Vector3d>(config, OFFSET_KEY));
+  Eigen::Vector3d dir(getEntry<double>(config, "x"), getEntry<double>(config, "y"), getEntry<double>(config, "z"));
+
+  ui_->double_spin_box_x->setValue(dir.x());
+  ui_->double_spin_box_y->setValue(dir.y());
+  ui_->double_spin_box_z->setValue(dir.z());
   n_points_->setValue(getEntry<int>(config, N_POINTS_KEY));
 }
 
 void LinearApproachToolPathModifierWidget::save(YAML::Node& config) const
 {
-  config[OFFSET_HEIGHT_KEY] = offset_height_->value();
+//  config[OFFSET_KEY] = offset_->value();
+  config["x"] = ui_->double_spin_box_x->value();
+  config["y"] = ui_->double_spin_box_y->value();
+  config["z"] = ui_->double_spin_box_z->value();
   config[N_POINTS_KEY] = n_points_->value();
 }
 

--- a/noether_gui/src/widgets/tool_path_modifiers/linear_approach_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/linear_approach_modifier_widget.cpp
@@ -1,7 +1,7 @@
-#include <noether_gui/widgets/tool_path_modifiers/straight_approach_modifier_widget.h>
+#include <noether_gui/widgets/tool_path_modifiers/linear_approach_modifier_widget.h>
 #include <noether_gui/utils.h>
 
-#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>
+#include <noether_tpp/tool_path_modifiers/linear_approach_modifier.h>
 #include <QFormLayout>
 #include <QLabel>
 #include <QDoubleSpinBox>
@@ -11,7 +11,7 @@ static const std::string N_POINTS_KEY = "n_points";
 
 namespace noether
 {
-StraightApproachToolPathModifierWidget::StraightApproachToolPathModifierWidget(QWidget* parent)
+LinearApproachToolPathModifierWidget::LinearApproachToolPathModifierWidget(QWidget* parent)
   : ToolPathModifierWidget(parent)
 {
   auto layout = new QFormLayout(this);
@@ -37,19 +37,19 @@ StraightApproachToolPathModifierWidget::StraightApproachToolPathModifierWidget(Q
   setLayout(layout);
 }
 
-ToolPathModifier::ConstPtr StraightApproachToolPathModifierWidget::create() const
+ToolPathModifier::ConstPtr LinearApproachToolPathModifierWidget::create() const
 {
-  return std::make_unique<StraightApproachModifier>(offset_height_->value(), n_points_->value());
+  return std::make_unique<LinearApproachModifier>(offset_height_->value(), n_points_->value());
 }
 
 
-void StraightApproachToolPathModifierWidget::configure(const YAML::Node& config)
+void LinearApproachToolPathModifierWidget::configure(const YAML::Node& config)
 {
   offset_height_->setValue(getEntry<double>(config, OFFSET_HEIGHT_KEY));
   n_points_->setValue(getEntry<int>(config, N_POINTS_KEY));
 }
 
-void StraightApproachToolPathModifierWidget::save(YAML::Node& config) const
+void LinearApproachToolPathModifierWidget::save(YAML::Node& config) const
 {
   config[OFFSET_HEIGHT_KEY] = offset_height_->value();
   config[N_POINTS_KEY] = n_points_->value();

--- a/noether_gui/src/widgets/tool_path_modifiers/linear_approach_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/linear_approach_modifier_widget.cpp
@@ -16,31 +16,6 @@ namespace noether
 LinearApproachToolPathModifierWidget::LinearApproachToolPathModifierWidget(QWidget* parent)
   : ToolPathModifierWidget(parent), ui_(new Ui::Vector3dEditor())
 {
-//  auto layout = new QFormLayout(this);
-//  // Height Offset
-////  offset_ = new QDoubleSpinBox(this);
-////  offset_->setMinimum(0.0);
-////  offset_->setSingleStep(0.01);
-////  offset_->setValue(0.1);
-////  offset_->setDecimals(3);
-////  auto label_offset = new QLabel("Height offset (m)", this);
-////  label_offset->setToolTip("Distance from the first segment point to the first point of the approach trajectory");
-////  layout->addRow(label_offset, offset_);
-//  ui_->setupUi(this);
-//  ui_->group_box->setTitle("Offset (m)");
-
-//  ui_->double_spin_box_z->setValue(0.1);
-
-//  // Number of points
-//  n_points_ = new QSpinBox(this);
-//  n_points_->setMinimum(0.0);
-//  n_points_->setSingleStep(1);
-//  n_points_->setValue(5);
-//  auto label_pnt = new QLabel("Lead in number of points", this);
-//  label_pnt->setToolTip("Number of waypoints along the approach trajectory");
-//  layout->addRow(label_pnt, n_points_);
-
-//  setLayout(layout);
   // Create a vertical layout for the entire widget
   auto mainLayout = new QVBoxLayout(this);
 

--- a/noether_gui/src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
@@ -37,6 +37,12 @@ StraightApproachToolPathModifierWidget::StraightApproachToolPathModifierWidget(Q
   setLayout(layout);
 }
 
+ToolPathModifier::ConstPtr StraightApproachToolPathModifierWidget::create() const
+{
+  return std::make_unique<StraightApproachModifier>(offset_height_->value(), n_points_->value());
+}
+
+
 void StraightApproachToolPathModifierWidget::configure(const YAML::Node& config)
 {
   offset_height_->setValue(getEntry<double>(config, OFFSET_HEIGHT_KEY));

--- a/noether_gui/src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
@@ -1,0 +1,52 @@
+#include <noether_gui/widgets/tool_path_modifiers/straight_approach_modifier_widget.h>
+#include <noether_gui/utils.h>
+
+#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>
+#include <QFormLayout>
+#include <QLabel>
+#include <QDoubleSpinBox>
+
+static const std::string OFFSET_HEIGHT_KEY = "offset_height";
+static const std::string N_POINTS_KEY = "n_points";
+
+namespace noether
+{
+StraightApproachToolPathModifierWidget::StraightApproachToolPathModifierWidget(QWidget* parent)
+  : ToolPathModifierWidget(parent)
+{
+  auto layout = new QFormLayout(this);
+
+  // Height Offset
+  offset_height_ = new QDoubleSpinBox(this);
+  offset_height_->setMinimum(0.0);
+  offset_height_->setSingleStep(0.01);
+  offset_height_->setValue(0.1);
+  offset_height_->setDecimals(3);
+  auto label_offset = new QLabel("Height offset (m)", this);
+  label_offset->setToolTip("Distance from the first segment point to the first point of the approach trajectory");
+  layout->addRow(label_offset, offset_height_);
+  // Number of points
+  n_points_ = new QSpinBox(this);
+  n_points_->setMinimum(0.0);
+  n_points_->setSingleStep(1);
+  n_points_->setValue(5);
+  auto label_pnt = new QLabel("Lead in number of points", this);
+  label_pnt->setToolTip("Number of waypoints along the approach trajectory");
+  layout->addRow(label_pnt, n_points_);
+
+  setLayout(layout);
+}
+
+void StraightApproachToolPathModifierWidget::configure(const YAML::Node& config)
+{
+  offset_height_->setValue(getEntry<double>(config, OFFSET_HEIGHT_KEY));
+  n_points_->setValue(getEntry<int>(config, N_POINTS_KEY));
+}
+
+void StraightApproachToolPathModifierWidget::save(YAML::Node& config) const
+{
+  config[OFFSET_HEIGHT_KEY] = offset_height_->value();
+  config[N_POINTS_KEY] = n_points_->value();
+}
+
+}  // namespace noether

--- a/noether_gui/src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/straight_approach_modifier_widget.cpp
@@ -1,0 +1,58 @@
+#include <noether_gui/widgets/tool_path_modifiers/straight_approach_modifier_widget.h>
+#include <noether_gui/utils.h>
+
+#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>
+#include <QFormLayout>
+#include <QLabel>
+#include <QDoubleSpinBox>
+
+static const std::string OFFSET_HEIGHT_KEY = "offset_height";
+static const std::string N_POINTS_KEY = "n_points";
+
+namespace noether
+{
+StraightApproachToolPathModifierWidget::StraightApproachToolPathModifierWidget(QWidget* parent)
+  : ToolPathModifierWidget(parent)
+{
+  auto layout = new QFormLayout(this);
+
+  // Height Offset
+  offset_height_ = new QDoubleSpinBox(this);
+  offset_height_->setMinimum(0.0);
+  offset_height_->setSingleStep(0.01);
+  offset_height_->setValue(0.1);
+  offset_height_->setDecimals(3);
+  auto label_offset = new QLabel("Height offset (m)", this);
+  label_offset->setToolTip("Distance from the first segment point to the first point of the approach trajectory");
+  layout->addRow(label_offset, offset_height_);
+  // Number of points
+  n_points_ = new QSpinBox(this);
+  n_points_->setMinimum(0.0);
+  n_points_->setSingleStep(1);
+  n_points_->setValue(5);
+  auto label_pnt = new QLabel("Lead in number of points", this);
+  label_pnt->setToolTip("Number of waypoints along the approach trajectory");
+  layout->addRow(label_pnt, n_points_);
+
+  setLayout(layout);
+}
+
+ToolPathModifier::ConstPtr StraightApproachToolPathModifierWidget::create() const
+{
+  return std::make_unique<StraightApproachModifier>(offset_height_->value(), n_points_->value());
+}
+
+
+void StraightApproachToolPathModifierWidget::configure(const YAML::Node& config)
+{
+  offset_height_->setValue(getEntry<double>(config, OFFSET_HEIGHT_KEY));
+  n_points_->setValue(getEntry<int>(config, N_POINTS_KEY));
+}
+
+void StraightApproachToolPathModifierWidget::save(YAML::Node& config) const
+{
+  config[OFFSET_HEIGHT_KEY] = offset_height_->value();
+  config[N_POINTS_KEY] = n_points_->value();
+}
+
+}  // namespace noether

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -209,7 +209,6 @@ void TPPWidget::onPlan(const bool /*checked*/)
     QApplication::setOverrideCursor(Qt::WaitCursor);
     tool_paths_ = pipeline.plan(mesh);
     QApplication::restoreOverrideCursor();
-
     // Render the tool paths
     std::for_each(tool_path_actors_.begin(), tool_path_actors_.end(), [this](vtkProp* actor) {
       renderer_->RemoveActor(actor);

--- a/noether_gui/ui/vector3d_editor_widget.ui
+++ b/noether_gui/ui/vector3d_editor_widget.ui
@@ -6,12 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>234</width>
-    <height>167</height>
+    <width>342</width>
+    <height>186</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
+  </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
@@ -40,6 +43,9 @@
           <property name="maximum">
            <double>100.000000000000000</double>
           </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
          </widget>
         </item>
         <item row="1" column="0">
@@ -59,6 +65,9 @@
           </property>
           <property name="maximum">
            <double>100.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
           <property name="value">
            <double>0.000000000000000</double>
@@ -82,6 +91,9 @@
           </property>
           <property name="maximum">
            <double>100.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
          </widget>
         </item>

--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(${PROJECT_NAME} SHARED
   src/tool_path_modifiers/raster_organization_modifier.cpp
   src/tool_path_modifiers/snake_organization_modifier.cpp
   src/tool_path_modifiers/standard_edge_paths_organization_modifier.cpp
+  src/tool_path_modifiers/straight_approach_modifier.cpp
   src/tool_path_modifiers/tool_drag_orientation_modifier.cpp
   src/tool_path_modifiers/uniform_orientation_modifier.cpp
   # Tool Path Planners

--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -41,7 +41,7 @@ add_library(${PROJECT_NAME} SHARED
   src/tool_path_modifiers/raster_organization_modifier.cpp
   src/tool_path_modifiers/snake_organization_modifier.cpp
   src/tool_path_modifiers/standard_edge_paths_organization_modifier.cpp
-  src/tool_path_modifiers/straight_approach_modifier.cpp
+  src/tool_path_modifiers/linear_approach_modifier.cpp
   src/tool_path_modifiers/tool_drag_orientation_modifier.cpp
   src/tool_path_modifiers/uniform_orientation_modifier.cpp
   # Tool Path Planners

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
@@ -10,12 +10,22 @@ namespace noether
 class LinearApproachModifier : public ToolPathModifier
 {
 public:
-  LinearApproachModifier(double offset_height_, double n_points);
+  enum class Axis
+  {
+    X,
+    Y,
+    Z,
+  };
+
+  LinearApproachModifier(Eigen::Vector3d offset, std::size_t n_points);
+  LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points);
   ToolPaths modify(ToolPaths tool_paths) const override final;
 
+
+
 protected:
-  const double offset_height_;
-  const double n_points_;
+  Eigen::Vector3d offset_;
+  const size_t n_points_;
 };
 
 }  // namespace noether

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
@@ -10,18 +10,16 @@ namespace noether
 class LinearApproachModifier : public ToolPathModifier
 {
 public:
-  enum class Axis
-  {
-    X,
-    Y,
-    Z,
-  };
+//  enum class Axis
+//  {
+//    X,
+//    Y,
+//    Z,
+//  };
 
   LinearApproachModifier(Eigen::Vector3d offset, std::size_t n_points);
-  LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points);
+//  LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points);
   ToolPaths modify(ToolPaths tool_paths) const override final;
-
-
 
 protected:
   Eigen::Vector3d offset_;

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
@@ -7,10 +7,10 @@ namespace noether
 /**
  * @brief Modifier that adjusts the parameters of the tool approach trajectory to the media
  */
-class StraightApproachModifier : public ToolPathModifier
+class LinearApproachModifier : public ToolPathModifier
 {
 public:
-  StraightApproachModifier(double offset_height_, double n_points);
+  LinearApproachModifier(double offset_height_, double n_points);
   ToolPaths modify(ToolPaths tool_paths) const override final;
 
 protected:

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
@@ -10,15 +10,8 @@ namespace noether
 class LinearApproachModifier : public ToolPathModifier
 {
 public:
-//  enum class Axis
-//  {
-//    X,
-//    Y,
-//    Z,
-//  };
 
   LinearApproachModifier(Eigen::Vector3d offset, std::size_t n_points);
-//  LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points);
   ToolPaths modify(ToolPaths tool_paths) const override final;
 
 protected:

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/straight_approach_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/straight_approach_modifier.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <noether_tpp/core/tool_path_modifier.h>
+
+namespace noether
+{
+/**
+ * @brief Modifier that adjusts the parameters of the tool approach trajectory to the media
+ */
+class StraightApproachModifier : public ToolPathModifier
+{
+public:
+  StraightApproachModifier(double offset_height_, double n_points);
+  ToolPaths modify(ToolPaths tool_paths) const override final;
+
+protected:
+  const double offset_height_;
+  const double n_points_;
+};
+
+}  // namespace noether

--- a/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
@@ -3,26 +3,27 @@
 
 namespace noether
 {
-  LinearApproachModifier(Eigen::Vector3d offset, std::size_t n_points)
+  LinearApproachModifier::LinearApproachModifier(Eigen::Vector3d offset, std::size_t n_points)
     : offset_(offset), n_points_(n_points)
   {
   }
 
-  LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points)
-    : n_points_(n_points)
-  {
-    switch(axis)
-    {
-      case Axis::X:
-        offset_ = Eigen::Vector3d::UnitX() * offset;
-      case Axis::Y:
-        offset_ = Eigen::Vector3d::UnitY() * offset;
-      case Axis::Z:
-        offset_ = Eigen::Vector3d::UnitZ() * offset;
-      default:
-        throw std::runtime_error("Invalid axis enumeration");
-    }
-  }
+//  LinearApproachModifier::LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points)
+//    : n_points_(n_points)
+//  {
+//    switch(axis)
+//    {
+//      case Axis::X:
+//        offset_ = Eigen::Vector3d::UnitX().cwiseProduct(offset);
+//        offset_ = Eigen::Vector3d(offset, 0, 0);
+//      case Axis::Y:
+//        offset_ = Eigen::Vector3d::UnitY().cwiseProduct(offset);
+//      case Axis::Z:
+//        offset_ = Eigen::Vector3d::UnitZ().cwiseProduct(offset);
+//      default:
+//        throw std::runtime_error("Invalid axis enumeration");
+//    }
+//  }
 
 ToolPaths LinearApproachModifier::modify(ToolPaths tool_paths) const
 {
@@ -30,14 +31,14 @@ ToolPaths LinearApproachModifier::modify(ToolPaths tool_paths) const
   {
     for (ToolPathSegment& segment : tool_path)
     {
-      Eigen::Isometry3d offset_point = segment.front() * Eigen::Translation3d(0.0, 0.0, offset_height_);
+      Eigen::Isometry3d offset_point = segment.front() * Eigen::Translation3d(offset_);
       ToolPathSegment new_segment;
 
 
       for (int i = 0; i < n_points_; i++)
       {
         Eigen::Isometry3d pt;
-        pt = offset_point * Eigen::Translation3d(0, 0, -(offset_/(n_points_)*i));
+        pt = offset_point * Eigen::Translation3d(-(offset_/(n_points_)*i));
         pt.linear() = segment.front().linear();
         new_segment.push_back(pt);
       }

--- a/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
@@ -1,14 +1,14 @@
-#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>
+#include <noether_tpp/tool_path_modifiers/linear_approach_modifier.h>
 #include <noether_tpp/utils.h>
 
 namespace noether
 {
-StraightApproachModifier::StraightApproachModifier(double offset_height, double n_points)
+LinearApproachModifier::LinearApproachModifier(double offset_height, double n_points)
   : offset_height_(offset_height), n_points_(n_points)
 {
 }
 
-ToolPaths StraightApproachModifier::modify(ToolPaths tool_paths) const
+ToolPaths LinearApproachModifier::modify(ToolPaths tool_paths) const
 {
   for (ToolPath& tool_path : tool_paths)
   {

--- a/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
@@ -3,33 +3,46 @@
 
 namespace noether
 {
-LinearApproachModifier::LinearApproachModifier(double offset_height, double n_points)
-  : offset_height_(offset_height), n_points_(n_points)
-{
-}
+  LinearApproachModifier(Eigen::Vector3d offset, std::size_t n_points)
+    : offset_(offset), n_points_(n_points)
+  {
+  }
+
+  LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points)
+    : n_points_(n_points)
+  {
+    switch(axis)
+    {
+      case Axis::X:
+        offset_ = Eigen::Vector3d::UnitX() * offset;
+      case Axis::Y:
+        offset_ = Eigen::Vector3d::UnitY() * offset;
+      case Axis::Z:
+        offset_ = Eigen::Vector3d::UnitZ() * offset;
+      default:
+        throw std::runtime_error("Invalid axis enumeration");
+    }
+  }
 
 ToolPaths LinearApproachModifier::modify(ToolPaths tool_paths) const
 {
   for (ToolPath& tool_path : tool_paths)
   {
-    Eigen::Vector3d dir = estimateToolPathDirection(tool_path);
-    const Eigen::Isometry3d& first = tool_path.at(0).at(0);
-    const Eigen::Vector3d& y = first.matrix().col(1).head<3>();
-    const Eigen::Vector3d& z = first.matrix().col(2).head<3>();
     for (ToolPathSegment& segment : tool_path)
     {
       Eigen::Isometry3d offset_point = segment.front() * Eigen::Translation3d(0.0, 0.0, offset_height_);
       ToolPathSegment new_segment;
 
+
       for (int i = 0; i < n_points_; i++)
       {
         Eigen::Isometry3d pt;
-        pt = offset_point * Eigen::Translation3d(0, 0, -offset_height_ + (offset_height_/(n_points_))*i);
+        pt = offset_point * Eigen::Translation3d(0, 0, -(offset_/(n_points_)*i));
         pt.linear() = segment.front().linear();
         new_segment.push_back(pt);
       }
 
-      segment.insert(segment.begin(), new_segment.rbegin(), new_segment.rend());
+    segment.insert(segment.begin(), new_segment.begin(), new_segment.end());
     }
   }
 

--- a/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
@@ -8,23 +8,6 @@ namespace noether
   {
   }
 
-//  LinearApproachModifier::LinearApproachModifier(Eigen::Vector3d offset, Axis axis, std::size_t n_points)
-//    : n_points_(n_points)
-//  {
-//    switch(axis)
-//    {
-//      case Axis::X:
-//        offset_ = Eigen::Vector3d::UnitX().cwiseProduct(offset);
-//        offset_ = Eigen::Vector3d(offset, 0, 0);
-//      case Axis::Y:
-//        offset_ = Eigen::Vector3d::UnitY().cwiseProduct(offset);
-//      case Axis::Z:
-//        offset_ = Eigen::Vector3d::UnitZ().cwiseProduct(offset);
-//      default:
-//        throw std::runtime_error("Invalid axis enumeration");
-//    }
-//  }
-
 ToolPaths LinearApproachModifier::modify(ToolPaths tool_paths) const
 {
   for (ToolPath& tool_path : tool_paths)

--- a/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
@@ -1,4 +1,4 @@
-#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>.h>
+#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>
 #include <noether_tpp/utils.h>
 
 namespace noether
@@ -10,16 +10,12 @@ StraightApproachModifier::StraightApproachModifier(double offset_height, double 
 
 ToolPaths StraightApproachModifier::modify(ToolPaths tool_paths) const
 {
-//  double delta_theta = arc_angle_ / (n_points_ - 1);
   for (ToolPath& tool_path : tool_paths)
   {
     Eigen::Vector3d dir = estimateToolPathDirection(tool_path);
     const Eigen::Isometry3d& first = tool_path.at(0).at(0);
     const Eigen::Vector3d& y = first.matrix().col(1).head<3>();
     const Eigen::Vector3d& z = first.matrix().col(2).head<3>();
-    // Sign is determined by whether the first point's y-axis is aligned with the nominal path y-axis (i.e., the cross
-    // of the waypoint's z-axis with the nominal path direction)
-    double sign = z.cross(dir).dot(y) > 0.0 ? 1.0 : -1.0;
     for (ToolPathSegment& segment : tool_path)
     {
       Eigen::Isometry3d radius_center = segment.front() * Eigen::Translation3d(0.0, 0.0, offset_height_);
@@ -28,11 +24,7 @@ ToolPaths StraightApproachModifier::modify(ToolPaths tool_paths) const
       for (int i = 0; i < n_points_; i++)
       {
         Eigen::Isometry3d pt;
-//        if (i == 0 || i==n_points_-1){
-          /*Eigen::Isometry3d */pt = radius_center *
-//                               Eigen::AngleAxisd(sign * delta_theta * (i + 1), Eigen::Vector3d::UnitY()) *
-                               Eigen::Translation3d(0, 0, -offset_height_ + (offset_height_/(n_points_))*i);
-//        }
+        pt = radius_center * Eigen::Translation3d(0, 0, -offset_height_ + (offset_height_/(n_points_))*i);
         pt.linear() = segment.front().linear();
         new_segment.push_back(pt);
       }

--- a/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
@@ -1,0 +1,47 @@
+#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>.h>
+#include <noether_tpp/utils.h>
+
+namespace noether
+{
+StraightApproachModifier::StraightApproachModifier(double offset_height, double n_points)
+  : offset_height_(offset_height), n_points_(n_points)
+{
+}
+
+ToolPaths StraightApproachModifier::modify(ToolPaths tool_paths) const
+{
+//  double delta_theta = arc_angle_ / (n_points_ - 1);
+  for (ToolPath& tool_path : tool_paths)
+  {
+    Eigen::Vector3d dir = estimateToolPathDirection(tool_path);
+    const Eigen::Isometry3d& first = tool_path.at(0).at(0);
+    const Eigen::Vector3d& y = first.matrix().col(1).head<3>();
+    const Eigen::Vector3d& z = first.matrix().col(2).head<3>();
+    // Sign is determined by whether the first point's y-axis is aligned with the nominal path y-axis (i.e., the cross
+    // of the waypoint's z-axis with the nominal path direction)
+    double sign = z.cross(dir).dot(y) > 0.0 ? 1.0 : -1.0;
+    for (ToolPathSegment& segment : tool_path)
+    {
+      Eigen::Isometry3d radius_center = segment.front() * Eigen::Translation3d(0.0, 0.0, offset_height_);
+      ToolPathSegment new_segment;
+
+      for (int i = 0; i < n_points_; i++)
+      {
+        Eigen::Isometry3d pt;
+//        if (i == 0 || i==n_points_-1){
+          /*Eigen::Isometry3d */pt = radius_center *
+//                               Eigen::AngleAxisd(sign * delta_theta * (i + 1), Eigen::Vector3d::UnitY()) *
+                               Eigen::Translation3d(0, 0, -offset_height_ + (offset_height_/(n_points_))*i);
+//        }
+        pt.linear() = segment.front().linear();
+        new_segment.push_back(pt);
+      }
+
+      segment.insert(segment.begin(), new_segment.rbegin(), new_segment.rend());
+    }
+  }
+
+  return tool_paths;
+}
+
+}  // namespace noether

--- a/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
@@ -18,13 +18,13 @@ ToolPaths StraightApproachModifier::modify(ToolPaths tool_paths) const
     const Eigen::Vector3d& z = first.matrix().col(2).head<3>();
     for (ToolPathSegment& segment : tool_path)
     {
-      Eigen::Isometry3d radius_center = segment.front() * Eigen::Translation3d(0.0, 0.0, offset_height_);
+      Eigen::Isometry3d offset_point = segment.front() * Eigen::Translation3d(0.0, 0.0, offset_height_);
       ToolPathSegment new_segment;
 
       for (int i = 0; i < n_points_; i++)
       {
         Eigen::Isometry3d pt;
-        pt = radius_center * Eigen::Translation3d(0, 0, -offset_height_ + (offset_height_/(n_points_))*i);
+        pt = offset_point * Eigen::Translation3d(0, 0, -offset_height_ + (offset_height_/(n_points_))*i);
         pt.linear() = segment.front().linear();
         new_segment.push_back(pt);
       }

--- a/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/straight_approach_modifier.cpp
@@ -1,0 +1,39 @@
+#include <noether_tpp/tool_path_modifiers/straight_approach_modifier.h>
+#include <noether_tpp/utils.h>
+
+namespace noether
+{
+StraightApproachModifier::StraightApproachModifier(double offset_height, double n_points)
+  : offset_height_(offset_height), n_points_(n_points)
+{
+}
+
+ToolPaths StraightApproachModifier::modify(ToolPaths tool_paths) const
+{
+  for (ToolPath& tool_path : tool_paths)
+  {
+    Eigen::Vector3d dir = estimateToolPathDirection(tool_path);
+    const Eigen::Isometry3d& first = tool_path.at(0).at(0);
+    const Eigen::Vector3d& y = first.matrix().col(1).head<3>();
+    const Eigen::Vector3d& z = first.matrix().col(2).head<3>();
+    for (ToolPathSegment& segment : tool_path)
+    {
+      Eigen::Isometry3d offset_point = segment.front() * Eigen::Translation3d(0.0, 0.0, offset_height_);
+      ToolPathSegment new_segment;
+
+      for (int i = 0; i < n_points_; i++)
+      {
+        Eigen::Isometry3d pt;
+        pt = offset_point * Eigen::Translation3d(0, 0, -offset_height_ + (offset_height_/(n_points_))*i);
+        pt.linear() = segment.front().linear();
+        new_segment.push_back(pt);
+      }
+
+      segment.insert(segment.begin(), new_segment.rbegin(), new_segment.rend());
+    }
+  }
+
+  return tool_paths;
+}
+
+}  // namespace noether


### PR DESCRIPTION
Added a toolpath and widget where the user can select an offset height from the first waypoint of each raster and interpolate that height with a desired number of waypoints. 
![straight_approach_toolpath](https://github.com/ros-industrial/noether/assets/76972296/1d0c97a4-2285-46cf-a45d-c9e339e1ab5f)
