### PR TITLE
Added visualization tool that allows user to toggle visibility of applie…

### DIFF
--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -50,9 +50,6 @@ public:
   void setMeshFile(const QString& file);
   void setConfigurationFile(const QString& file);
 
-
-
-
 private:
   void onLoadMesh(const bool /*checked*/);
   void onLoadConfiguration(const bool /*checked*/);
@@ -82,7 +79,6 @@ private:
   vtkTubeFilter* tube_filter_;
 
   std::vector<ToolPaths> tool_paths_;
-
 };
 
 }  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -2,7 +2,6 @@
 
 #include <noether_tpp/core/types.h>
 #include <QWidget>
-#include <QCheckBox>
 #include <vtkSmartPointer.h>
 
 class QVTKWidget;
@@ -51,8 +50,7 @@ public:
   void setMeshFile(const QString& file);
   void setConfigurationFile(const QString& file);
 
-//private slots:
-//  void onShowOriginalMesh(const bool /*checked*/);
+
 
 
 private:
@@ -84,7 +82,6 @@ private:
   vtkTubeFilter* tube_filter_;
 
   std::vector<ToolPaths> tool_paths_;
-//  QPushButton *push_button_show_original_mesh;
 
 };
 

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -38,7 +38,6 @@ class TPPWidget : public QWidget
   Q_OBJECT
 public:
   TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent = nullptr);
-  virtual ~TPPWidget();
 
   /**
    * @brief Get the planned tool paths
@@ -65,18 +64,16 @@ private:
 
   // Viewer rendering
   QVTKWidget* render_widget_;
-  vtkRenderer* renderer_;
-  vtkPolyDataMapper* mesh_mapper_;
-  vtkActor* mesh_actor_;
+  vtkSmartPointer<vtkRenderer> renderer_;
+  vtkSmartPointer<vtkPolyDataMapper> mesh_mapper_;
+  vtkSmartPointer<vtkActor> mesh_actor_;
 
-  vtkPolyDataMapper* mesh_fragment_mapper_;
-  vtkActor* mesh_fragment_actor_;
-  vtkSmartPointer<vtkPolyData> combined_mesh_fragments_;
+  vtkSmartPointer<vtkAssembly> tool_path_actor_;
+  vtkSmartPointer<vtkAssembly> unmodified_tool_path_actor_;
+  vtkSmartPointer<vtkAssembly> mesh_fragment_actor_;
 
-  vtkAssembly* tool_path_actor_;
-  vtkAssembly* unmodified_tool_path_actor_;
-  vtkAxes* axes_;
-  vtkTubeFilter* tube_filter_;
+  vtkSmartPointer<vtkAxes> axes_;
+  vtkSmartPointer<vtkTubeFilter> tube_filter_;
 
   std::vector<ToolPaths> tool_paths_;
 };

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -2,6 +2,8 @@
 
 #include <noether_tpp/core/types.h>
 #include <QWidget>
+#include <QCheckBox>
+#include <vtkSmartPointer.h>
 
 class QVTKWidget;
 class vtkActor;
@@ -10,6 +12,8 @@ class vtkProp;
 class vtkRenderer;
 class vtkAxes;
 class vtkTubeFilter;
+class vtkAssembly;
+class vtkPolyData;
 
 namespace boost_plugin_loader
 {
@@ -47,11 +51,19 @@ public:
   void setMeshFile(const QString& file);
   void setConfigurationFile(const QString& file);
 
+//private slots:
+//  void onShowOriginalMesh(const bool /*checked*/);
+
+
 private:
   void onLoadMesh(const bool /*checked*/);
   void onLoadConfiguration(const bool /*checked*/);
   void onSaveConfiguration(const bool /*checked*/);
   void onPlan(const bool /*checked*/);
+  void onShowOriginalMesh(const bool);
+  void onShowModifiedMesh(const bool);
+  void onShowUnmodifiedToolPath(const bool);
+  void onShowModifiedToolPath(const bool);
 
   Ui::TPP* ui_;
   TPPPipelineWidget* pipeline_widget_;
@@ -61,11 +73,19 @@ private:
   vtkRenderer* renderer_;
   vtkPolyDataMapper* mesh_mapper_;
   vtkActor* mesh_actor_;
-  std::vector<vtkProp*> tool_path_actors_;
+
+  vtkPolyDataMapper* mesh_fragment_mapper_;
+  vtkActor* mesh_fragment_actor_;
+  vtkSmartPointer<vtkPolyData> combined_mesh_fragments_;
+
+  vtkAssembly* tool_path_actor_;
+  vtkAssembly* unmodified_tool_path_actor_;
   vtkAxes* axes_;
   vtkTubeFilter* tube_filter_;
 
   std::vector<ToolPaths> tool_paths_;
+//  QPushButton *push_button_show_original_mesh;
+
 };
 
 }  // namespace noether

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -284,32 +284,27 @@ vtkAssembly* createToolPathActors(const std::vector<ToolPaths>& tool_paths,
 /**
  * @brief Corrected version of pcl::PolygonMesh::concatenate to support PCL versions before 1.12
  */
-static bool concatenate (pcl::PolygonMesh &mesh1, const pcl::PolygonMesh &mesh2)
+static bool concatenate(pcl::PolygonMesh& mesh1, const pcl::PolygonMesh& mesh2)
 {
   // Compute point offset with mesh1 before modifying mesh1
   const auto point_offset = mesh1.cloud.width * mesh1.cloud.height;
 
   bool success = pcl::PCLPointCloud2::concatenate(mesh1.cloud, mesh2.cloud);
-  if (success == false) {
+  if (success == false)
+  {
     return false;
   }
   // Make the resultant polygon mesh take the newest stamp
   mesh1.header.stamp = std::max(mesh1.header.stamp, mesh2.header.stamp);
 
-  std::transform(mesh2.polygons.begin (),
-                 mesh2.polygons.end (),
-                 std::back_inserter (mesh1.polygons),
-                 [point_offset](auto polygon)
-                 {
-                    std::transform(polygon.vertices.begin (),
-                                   polygon.vertices.end (),
-                                   polygon.vertices.begin (),
-                                   [point_offset](auto& point_idx)
-                                   {
-                                     return point_idx + point_offset;
-                                   });
-                    return polygon;
-                  });
+  std::transform(
+      mesh2.polygons.begin(), mesh2.polygons.end(), std::back_inserter(mesh1.polygons), [point_offset](auto polygon) {
+        std::transform(polygon.vertices.begin(),
+                       polygon.vertices.end(),
+                       polygon.vertices.begin(),
+                       [point_offset](auto& point_idx) { return point_idx + point_offset; });
+        return polygon;
+      });
 
   return true;
 }
@@ -339,7 +334,7 @@ void TPPWidget::onPlan(const bool /*checked*/)
     std::vector<ToolPaths> unmodified_tool_paths;
     unmodified_tool_paths.reserve(meshes.size());
 
-    for(const pcl::PolygonMesh& mesh : meshes)
+    for (const pcl::PolygonMesh& mesh : meshes)
     {
       concatenate(combined_mesh_fragments, mesh);
 
@@ -357,7 +352,6 @@ void TPPWidget::onPlan(const bool /*checked*/)
       pcl::VTKUtils::mesh2vtk(combined_mesh_fragments, combined_mesh_fragments_);
       mesh_fragment_mapper_->Update();
       mesh_fragment_mapper_->SetInputData(combined_mesh_fragments_);
-
     }
 
     // Render the unmodified tool paths

--- a/noether_gui/ui/tpp_widget.ui
+++ b/noether_gui/ui/tpp_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>355</width>
-    <height>421</height>
+    <width>1070</width>
+    <height>614</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -112,8 +112,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>309</width>
-               <height>133</height>
+               <width>1024</width>
+               <height>220</height>
               </rect>
              </property>
             </widget>
@@ -134,27 +134,68 @@
          <property name="title">
           <string>Viewer</string>
          </property>
-         <layout class="QFormLayout" name="formLayout_2">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <layout class="QFormLayout" name="formLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Axis Size (m)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="double_spin_box_axis_size">
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="maximum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.001000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.010000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="check_box_show_original_mesh">
             <property name="text">
-             <string>Axis Size (m)</string>
+             <string>Show Original Mesh</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <property name="tristate">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="double_spin_box_axis_size">
-            <property name="decimals">
-             <number>3</number>
+          <item>
+           <widget class="QCheckBox" name="check_box_show_modified_mesh">
+            <property name="text">
+             <string>Show Modified Mesh(es)</string>
             </property>
-            <property name="maximum">
-             <double>1.000000000000000</double>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="check_box_show_original_tool_path">
+            <property name="text">
+             <string>Show Original Tool Path</string>
             </property>
-            <property name="singleStep">
-             <double>0.001000000000000</double>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="check_box_show_modified_tool_path">
+            <property name="text">
+             <string>Show Modified Tool Path</string>
             </property>
-            <property name="value">
-             <double>0.010000000000000</double>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -172,8 +213,14 @@
   <tabstop>push_button_load_mesh</tabstop>
   <tabstop>line_edit_configuration</tabstop>
   <tabstop>push_button_load_configuration</tabstop>
+  <tabstop>push_button_save_configuration</tabstop>
   <tabstop>scroll_area</tabstop>
   <tabstop>push_button_plan</tabstop>
+  <tabstop>double_spin_box_axis_size</tabstop>
+  <tabstop>check_box_show_original_mesh</tabstop>
+  <tabstop>check_box_show_modified_mesh</tabstop>
+  <tabstop>check_box_show_original_tool_path</tabstop>
+  <tabstop>check_box_show_modified_tool_path</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/noether_tpp/include/noether_tpp/core/tool_path_planner_pipeline.h
+++ b/noether_tpp/include/noether_tpp/core/tool_path_planner_pipeline.h
@@ -39,11 +39,13 @@ public:
                           ToolPathModifier::ConstPtr tool_path_mod);
 
   std::vector<ToolPaths> plan(pcl::PolygonMesh mesh) const;
+  MeshModifier::ConstPtr mesh_modifier;
+  ToolPathPlanner::ConstPtr planner;
+  ToolPathModifier::ConstPtr tool_path_modifier;
+
 
 private:
-  MeshModifier::ConstPtr mesh_modifier_;
-  ToolPathPlanner::ConstPtr planner_;
-  ToolPathModifier::ConstPtr tool_path_modifier_;
+
 };
 
 }  // namespace noether

--- a/noether_tpp/include/noether_tpp/core/tool_path_planner_pipeline.h
+++ b/noether_tpp/include/noether_tpp/core/tool_path_planner_pipeline.h
@@ -44,7 +44,6 @@ public:
   ToolPathModifier::ConstPtr tool_path_modifier;
 
 
-private:
 
 };
 

--- a/noether_tpp/include/noether_tpp/core/tool_path_planner_pipeline.h
+++ b/noether_tpp/include/noether_tpp/core/tool_path_planner_pipeline.h
@@ -42,9 +42,6 @@ public:
   MeshModifier::ConstPtr mesh_modifier;
   ToolPathPlanner::ConstPtr planner;
   ToolPathModifier::ConstPtr tool_path_modifier;
-
-
-
 };
 
 }  // namespace noether

--- a/noether_tpp/src/core/tool_path_planner_pipeline.cpp
+++ b/noether_tpp/src/core/tool_path_planner_pipeline.cpp
@@ -7,20 +7,20 @@ namespace noether
 ToolPathPlannerPipeline::ToolPathPlannerPipeline(MeshModifier::ConstPtr mesh_mod,
                                                  ToolPathPlanner::ConstPtr planner,
                                                  ToolPathModifier::ConstPtr tool_path_mod)
-  : mesh_modifier_(std::move(mesh_mod)), planner_(std::move(planner)), tool_path_modifier_(std::move(tool_path_mod))
+  : mesh_modifier(std::move(mesh_mod)), planner(std::move(planner)), tool_path_modifier(std::move(tool_path_mod))
 {
 }
 
 std::vector<ToolPaths> ToolPathPlannerPipeline::plan(pcl::PolygonMesh mesh) const
 {
-  std::vector<pcl::PolygonMesh> meshes = mesh_modifier_->modify(mesh);
+  std::vector<pcl::PolygonMesh> meshes = mesh_modifier->modify(mesh);
 
   std::vector<ToolPaths> output;
   output.reserve(meshes.size());
   for (const pcl::PolygonMesh& mesh : meshes)
   {
-    ToolPaths path = planner_->plan(mesh);
-    output.push_back(tool_path_modifier_->modify(path));
+    ToolPaths path = planner->plan(mesh);
+    output.push_back(tool_path_modifier->modify(path));
   }
 
   return output;


### PR DESCRIPTION
…d tool path and mesh modifiers

I created a mesh modifier that splits a given mesh with an origin at (0,0,0) in half by filtering the points on one side of the y axis and saving the inlier and outlier meshes of this operation into one combined mesh.  

Originally, I used the concatenate() method from pcl::PolygonMesh to visualize the modified meshes into one combined mesh, but this resulted in a broken combined mesh. I verified that the inlier and outlier meshes from my mesh modifier were valid, and I confirmed that they could be concatenated into a single mesh in Open3D.  The combined mesh was then manually created from the given input meshes instead of using the concatenate() method. How the concatenate 
method combines meshes will require further investigation.

Below are images showing the functionality of the visualization tool. The checkboxes that are ticked show the components that they control the visibility of.

![orig_mesh_modif_tp](https://github.com/ros-industrial/noether/assets/76972296/ca71ca3e-3686-4a46-ab07-6b0bcf4dedd5)
![orig_mesh_orig_tp](https://github.com/ros-industrial/noether/assets/76972296/e84c2ef2-f40d-4354-ab2c-ce8eb4c4da77)
![modif_mesh](https://github.com/ros-industrial/noether/assets/76972296/2a55914e-89e2-4c57-8018-559de8d5f7ec)
![modif_mesh_orig_tp](https://github.com/ros-industrial/noether/assets/76972296/e5961304-417b-4594-b54f-a4860887fa2a)
![modif_mesh_modif_tp](https://github.com/ros-industrial/noether/assets/76972296/3f6c580a-7a67-49ca-8b27-4519cf3d584e)

