### PR TITLE
Create Configurable TPP Pipeline Widget

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -20,6 +20,7 @@ option(NOETHER_ENABLE_TESTING "Enables compilation of unit tests" OFF)
 qt5_wrap_cpp(${PROJECT_NAME}_widget_mocs
   include/${PROJECT_NAME}/widgets/collapsible_area_widget.h
   include/${PROJECT_NAME}/widgets/tpp_pipeline_widget.h
+  include/${PROJECT_NAME}/widgets/configurable_tpp_pipeline_widget.h
   include/${PROJECT_NAME}/widgets/tpp_widget.h
   # Tool Path Planners
   #   Raster
@@ -52,6 +53,7 @@ qt5_wrap_ui(${PROJECT_NAME}_widget_ui_mocs
   ui/linear_approach_modifier_widget.ui
   ui/raster_planner_widget.ui
   ui/tpp_pipeline_widget.ui
+  ui/configurable_tpp_pipeline_widget.ui
   ui/tpp_widget.ui)
 
 include_directories(include ${CMAKE_CURRENT_BINARY_DIR})
@@ -63,6 +65,7 @@ add_library(${PROJECT_NAME} SHARED
   src/widgets/collapsible_area_widget.cpp
   src/widgets/plugin_loader_widget.cpp
   src/widgets/tpp_pipeline_widget.cpp
+  src/widgets/configurable_tpp_pipeline_widget.cpp
   src/widgets/tpp_widget.cpp
   # Tool Path Planners
   #   Raster Planner

--- a/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
+++ b/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QWidget>
+#include <boost_plugin_loader/plugin_loader.h>
+
+namespace Ui
+{
+class ConfigurableTPPPipeline;
+}
+
+namespace noether
+{
+class TPPPipelineWidget;
+
+class ConfigurableTPPPipelineWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent = nullptr);
+
+  TPPPipelineWidget* pipeline_widget;
+  void setConfigurationFile(const QString& file);
+
+private:
+  void onLoadConfiguration(const bool /*checked*/);
+  void onSaveConfiguration(const bool /*checked*/);
+
+  Ui::ConfigurableTPPPipeline* ui_;
+};
+
+}  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
+++ b/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
@@ -2,10 +2,16 @@
 
 #include <QWidget>
 #include <boost_plugin_loader/plugin_loader.h>
+#include <noether_tpp/core/tool_path_planner_pipeline.h>
 
 namespace Ui
 {
 class ConfigurableTPPPipeline;
+}
+
+namespace YAML
+{
+class Node;
 }
 
 namespace noether
@@ -18,14 +24,18 @@ class ConfigurableTPPPipelineWidget : public QWidget
 public:
   ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent = nullptr);
 
-  TPPPipelineWidget* pipeline_widget;
   void setConfigurationFile(const QString& file);
+
+  ToolPathPlannerPipeline createPipeline() const;
+  void configure(const YAML::Node& config);
+  void save(YAML::Node& config) const;
 
 private:
   void onLoadConfiguration(const bool /*checked*/);
   void onSaveConfiguration(const bool /*checked*/);
 
   Ui::ConfigurableTPPPipeline* ui_;
+  TPPPipelineWidget* pipeline_widget_;
 };
 
 }  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
+++ b/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
@@ -28,6 +28,7 @@ public:
 
   ToolPathPlannerPipeline createPipeline() const;
   void configure(const YAML::Node& config);
+  void configure(const QString& file);
   void save(YAML::Node& config) const;
 
 private:

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
@@ -13,6 +13,8 @@ namespace YAML
 class Node;
 }
 
+class QVBoxLayout;
+
 namespace noether
 {
 /**
@@ -35,6 +37,7 @@ private:
   void addWidget(const QString& plugin_name, const YAML::Node& config);
 
   Ui::PluginLoader* ui_;
+  QVBoxLayout* widgets_layout_;
   const boost_plugin_loader::PluginLoader loader_;
 };
 

--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.hpp
@@ -13,9 +13,11 @@ template <typename PluginT>
 PluginLoaderWidget<PluginT>::PluginLoaderWidget(boost_plugin_loader::PluginLoader loader,
                                                 const QString& title,
                                                 QWidget* parent)
-  : QWidget(parent), ui_(new Ui::PluginLoader()), loader_(std::move(loader))
+  : QWidget(parent), ui_(new Ui::PluginLoader()), widgets_layout_(new QVBoxLayout()), loader_(std::move(loader))
 {
   ui_->setupUi(this);
+
+  ui_->contents->setLayout(widgets_layout_);
 
   ui_->group_box->setTitle(title);
   ui_->combo_box->addItems(getAvailablePlugins<PluginT>(loader_));
@@ -45,7 +47,7 @@ void PluginLoaderWidget<PluginT>::addWidget(const QString& plugin_name, const YA
   collapsible_area->setWidget(plugin->create(this, config));
   collapsible_area->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
 
-  ui_->vertical_layout_plugins->addWidget(collapsible_area);
+  widgets_layout_->addWidget(collapsible_area);
 
   // Add a right click menu option for deleting this tool path modifier widget
   connect(collapsible_area, &QWidget::customContextMenuRequested, [this, collapsible_area](const QPoint& pos) {
@@ -54,7 +56,7 @@ void PluginLoaderWidget<PluginT>::addWidget(const QString& plugin_name, const YA
     QAction* action = context_menu.exec(collapsible_area->mapToGlobal(pos));
     if (action == remove_action)
     {
-      ui_->vertical_layout_plugins->removeWidget(collapsible_area);
+      widgets_layout_->removeWidget(collapsible_area);
       delete collapsible_area;
     }
   });
@@ -67,9 +69,9 @@ template <typename PluginT>
 QWidgetList PluginLoaderWidget<PluginT>::getWidgets() const
 {
   QWidgetList widgets;
-  for (int i = 0; i < ui_->vertical_layout_plugins->count(); ++i)
+  for (int i = 0; i < widgets_layout_->count(); ++i)
   {
-    QLayoutItem* item = ui_->vertical_layout_plugins->itemAt(i);
+    QLayoutItem* item = widgets_layout_->itemAt(i);
     if (item)
     {
       auto collapsible_area = dynamic_cast<CollapsibleArea*>(item->widget());
@@ -96,9 +98,9 @@ void PluginLoaderWidget<PluginT>::configure(const YAML::Node& config)
 template <typename PluginT>
 void PluginLoaderWidget<PluginT>::save(YAML::Node& config) const
 {
-  for (int i = 0; i < ui_->vertical_layout_plugins->count(); ++i)
+  for (int i = 0; i < widgets_layout_->count(); ++i)
   {
-    QLayoutItem* item = ui_->vertical_layout_plugins->itemAt(i);
+    QLayoutItem* item = widgets_layout_->itemAt(i);
     if (item)
     {
       auto collapsible_area = dynamic_cast<const CollapsibleArea*>(item->widget());
@@ -121,9 +123,9 @@ void PluginLoaderWidget<PluginT>::save(YAML::Node& config) const
 template <typename PluginT>
 void PluginLoaderWidget<PluginT>::removeWidgets()
 {
-  for (int i = 0; i < ui_->vertical_layout_plugins->count(); ++i)
+  for (int i = 0; i < widgets_layout_->count(); ++i)
   {
-    ui_->vertical_layout_plugins->itemAt(i)->widget()->deleteLater();
+    widgets_layout_->itemAt(i)->widget()->deleteLater();
   }
 }
 

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -26,7 +26,7 @@ class TPP;
 
 namespace noether
 {
-class TPPPipelineWidget;
+class ConfigurableTPPPipelineWidget;
 
 /**
  * @brief Basic tool path planning widget
@@ -51,8 +51,6 @@ public:
 
 private:
   void onLoadMesh(const bool /*checked*/);
-  void onLoadConfiguration(const bool /*checked*/);
-  void onSaveConfiguration(const bool /*checked*/);
   void onPlan(const bool /*checked*/);
   void onShowOriginalMesh(const bool);
   void onShowModifiedMesh(const bool);
@@ -60,7 +58,7 @@ private:
   void onShowModifiedToolPath(const bool);
 
   Ui::TPP* ui_;
-  TPPPipelineWidget* pipeline_widget_;
+  ConfigurableTPPPipelineWidget* pipeline_widget_;
 
   // Viewer rendering
   QVTKWidget* render_widget_;

--- a/noether_gui/src/tpp_app.cpp
+++ b/noether_gui/src/tpp_app.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
 
   // Set the TPP widget as the central widget and show
   w.setCentralWidget(widget);
-  w.show();
+  w.showMaximized();
 
   return app.exec();
 }

--- a/noether_gui/src/widgets/collapsible_area_widget.cpp
+++ b/noether_gui/src/widgets/collapsible_area_widget.cpp
@@ -44,6 +44,8 @@ CollapsibleArea::CollapsibleArea(const QString& label, QWidget* parent)
   content->setStyleSheet("QScrollArea { border: none; }");
   content->setMaximumHeight(0);
   content->setMinimumHeight(0);
+  content->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  content->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
   animation_->addAnimation(new QPropertyAnimation(this, "minimumHeight"));
   animation_->addAnimation(new QPropertyAnimation(this, "maximumHeight"));

--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -1,0 +1,92 @@
+#include <noether_gui/widgets/configurable_tpp_pipeline_widget.h>
+#include <noether_gui/widgets/tpp_pipeline_widget.h>
+#include <noether_gui/utils.h>
+#include "ui_configurable_tpp_pipeline_widget.h"
+
+#include <fstream>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QTextStream>
+#include <QStandardPaths>
+#include <yaml-cpp/yaml.h>
+
+namespace noether
+{
+ConfigurableTPPPipelineWidget::ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
+  : QWidget(parent)
+  , pipeline_widget(new TPPPipelineWidget(std::move(loader), this))
+  , ui_(new Ui::ConfigurableTPPPipeline())
+{
+  ui_->setupUi(this);
+  layout()->addWidget(pipeline_widget);
+
+  // Connect
+  connect(ui_->push_button_load, &QPushButton::clicked, this, &ConfigurableTPPPipelineWidget::onLoadConfiguration);
+  connect(ui_->push_button_save, &QPushButton::clicked, this, &ConfigurableTPPPipelineWidget::onSaveConfiguration);
+}
+
+void ConfigurableTPPPipelineWidget::setConfigurationFile(const QString& file)
+{
+  ui_->line_edit->setText(file);
+
+  try
+  {
+    pipeline_widget->configure(YAML::LoadFile(file.toStdString()));
+  }
+  catch (const YAML::BadFile&)
+  {
+    QString message;
+    QTextStream ss;
+    ss << "Failed to open YAML file at '" << file << "'";
+    QMessageBox::warning(this, "Configuration Error", message);
+  }
+  catch (const std::exception& ex)
+  {
+    std::stringstream ss;
+    printException(ex, ss);
+    QMessageBox::warning(this, "Configuration Error", QString::fromStdString(ss.str()));
+  }
+}
+
+void ConfigurableTPPPipelineWidget::onLoadConfiguration(const bool /*checked*/)
+{
+  QString file = ui_->line_edit->text();
+  if (file.isEmpty())
+    file = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
+
+  file = QFileDialog::getOpenFileName(this, "Load configuration file", file, "YAML files (*.yaml)");
+  if (!file.isEmpty())
+    setConfigurationFile(file);
+}
+
+void ConfigurableTPPPipelineWidget::onSaveConfiguration(const bool /*checked*/)
+{
+  try
+  {
+    QString file = ui_->line_edit->text();
+    if (file.isEmpty())
+      file = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
+
+    file = QFileDialog::getSaveFileName(this, "Save configuration file", file, "YAML files (*.yaml)");
+    if (file.isEmpty())
+      return;
+
+    YAML::Node config;
+    pipeline_widget->save(config);
+
+    std::ofstream ofh(file.toStdString());
+    if (!ofh)
+      throw std::runtime_error("Failed to open output file at '" + file.toStdString() + "'");
+
+    ofh << config;
+    QMessageBox::information(this, "Configuration", "Successfully saved tool path planning pipeline configuration");
+  }
+  catch (const std::exception& ex)
+  {
+    std::stringstream ss;
+    printException(ex, ss);
+    QMessageBox::warning(this, "Save Error", QString::fromStdString(ss.str()));
+  }
+}
+
+}  // namespace noether

--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -14,16 +14,25 @@ namespace noether
 {
 ConfigurableTPPPipelineWidget::ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
   : QWidget(parent)
-  , pipeline_widget(new TPPPipelineWidget(std::move(loader), this))
   , ui_(new Ui::ConfigurableTPPPipeline())
+  , pipeline_widget_(new TPPPipelineWidget(std::move(loader), this))
 {
   ui_->setupUi(this);
-  layout()->addWidget(pipeline_widget);
+  layout()->addWidget(pipeline_widget_);
 
   // Connect
   connect(ui_->push_button_load, &QPushButton::clicked, this, &ConfigurableTPPPipelineWidget::onLoadConfiguration);
   connect(ui_->push_button_save, &QPushButton::clicked, this, &ConfigurableTPPPipelineWidget::onSaveConfiguration);
 }
+
+ToolPathPlannerPipeline ConfigurableTPPPipelineWidget::createPipeline() const
+{
+  return pipeline_widget_->createPipeline();
+}
+
+void ConfigurableTPPPipelineWidget::configure(const YAML::Node& config) { return pipeline_widget_->configure(config); }
+
+void ConfigurableTPPPipelineWidget::save(YAML::Node& config) const { return pipeline_widget_->save(config); }
 
 void ConfigurableTPPPipelineWidget::setConfigurationFile(const QString& file)
 {
@@ -31,7 +40,7 @@ void ConfigurableTPPPipelineWidget::setConfigurationFile(const QString& file)
 
   try
   {
-    pipeline_widget->configure(YAML::LoadFile(file.toStdString()));
+    configure(YAML::LoadFile(file.toStdString()));
   }
   catch (const YAML::BadFile&)
   {
@@ -72,7 +81,7 @@ void ConfigurableTPPPipelineWidget::onSaveConfiguration(const bool /*checked*/)
       return;
 
     YAML::Node config;
-    pipeline_widget->save(config);
+    save(config);
 
     std::ofstream ofh(file.toStdString());
     if (!ofh)

--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -32,6 +32,28 @@ ToolPathPlannerPipeline ConfigurableTPPPipelineWidget::createPipeline() const
 
 void ConfigurableTPPPipelineWidget::configure(const YAML::Node& config) { return pipeline_widget_->configure(config); }
 
+void ConfigurableTPPPipelineWidget::configure(const QString& file)
+{
+  try
+  {
+    configure(YAML::LoadFile(file.toStdString()));
+    ui_->line_edit->setText(file);
+  }
+  catch (const YAML::BadFile&)
+  {
+    QString message;
+    QTextStream ss(&message);
+    ss << "Failed to open YAML file at '" << file << "'";
+    QMessageBox::warning(this, "Configuration Error", message);
+  }
+  catch (const std::exception& ex)
+  {
+    std::stringstream ss;
+    noether::printException(ex, ss);
+    QMessageBox::warning(this, "Configuration Error", QString::fromStdString(ss.str()));
+  }
+}
+
 void ConfigurableTPPPipelineWidget::save(YAML::Node& config) const { return pipeline_widget_->save(config); }
 
 void ConfigurableTPPPipelineWidget::setConfigurationFile(const QString& file)

--- a/noether_gui/src/widgets/tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/tpp_pipeline_widget.cpp
@@ -68,12 +68,12 @@ TPPPipelineWidget::TPPPipelineWidget(boost_plugin_loader::PluginLoader loader, Q
       ui_->group_box_tpp->setTitle(text);
       if (text.isEmpty())
       {
-        overwriteWidget(ui_->group_box_tpp->layout(), ui_->widget_tpp, new QWidget(this));
+        ui_->scroll_area->setWidget(new QWidget(this));
       }
       else
       {
         auto plugin = loader_.createInstance<ToolPathPlannerWidgetPlugin>(text.toStdString());
-        overwriteWidget(ui_->group_box_tpp->layout(), ui_->widget_tpp, plugin->create(this));
+        ui_->scroll_area->setWidget(plugin->create(this));
       }
     }
     catch (const std::exception& ex)
@@ -98,7 +98,7 @@ void TPPPipelineWidget::configure(const YAML::Node& config)
       auto tpp_config = config[TOOL_PATH_PLANNER_KEY];
       auto name = getEntry<std::string>(tpp_config, "name");
       auto plugin = loader_.createInstance<ToolPathPlannerWidgetPlugin>(name);
-      overwriteWidget(ui_->group_box_tpp->layout(), ui_->widget_tpp, plugin->create(this, tpp_config));
+      ui_->scroll_area->setWidget(plugin->create(this, tpp_config));
       ui_->group_box_tpp->setTitle(QString::fromStdString(name));
     }
     catch (const std::exception&)
@@ -112,7 +112,7 @@ void TPPPipelineWidget::configure(const YAML::Node& config)
   catch (const std::exception&)
   {
     // Clear the widgets
-    overwriteWidget(ui_->group_box_tpp->layout(), ui_->widget_tpp, new QWidget(this));
+    ui_->scroll_area->setWidget(new QWidget(this));
     mesh_modifier_loader_widget_->removeWidgets();
     tool_path_modifier_loader_widget_->removeWidgets();
 
@@ -131,7 +131,7 @@ void TPPPipelineWidget::save(YAML::Node& config) const
 
   // Tool path planner
   {
-    auto tpp_widget = dynamic_cast<const ToolPathPlannerWidget*>(ui_->widget_tpp);
+    auto tpp_widget = dynamic_cast<const ToolPathPlannerWidget*>(ui_->scroll_area->widget());
     if (tpp_widget)
     {
       YAML::Node tpp_config;
@@ -151,7 +151,7 @@ void TPPPipelineWidget::save(YAML::Node& config) const
 
 ToolPathPlannerPipeline TPPPipelineWidget::createPipeline() const
 {
-  auto widget_tpp = dynamic_cast<ToolPathPlannerWidget*>(ui_->widget_tpp);
+  auto widget_tpp = dynamic_cast<ToolPathPlannerWidget*>(ui_->scroll_area->widget());
   if (!widget_tpp)
     throw std::runtime_error("No tool path planner specified");
 

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -1,5 +1,6 @@
 ﻿#include <noether_gui/widgets/tpp_widget.h>
 #include "ui_tpp_widget.h"
+#include <noether_gui/widgets/configurable_tpp_pipeline_widget.h>
 #include <noether_gui/widgets/tpp_pipeline_widget.h>
 #include <noether_gui/utils.h>
 
@@ -34,7 +35,7 @@ namespace noether
 TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
   : QWidget(parent)
   , ui_(new Ui::TPP())
-  , pipeline_widget_(new TPPPipelineWidget(std::move(loader), this))
+  , pipeline_widget_(new ConfigurableTPPPipelineWidget(std::move(loader), this))
   , render_widget_(new QVTKWidget(this))
   , renderer_(vtkSmartPointer<vtkOpenGLRenderer>::New())
   , mesh_mapper_(vtkSmartPointer<vtkOpenGLPolyDataMapper>::New())
@@ -80,8 +81,6 @@ TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
 
   // Connect signals
   connect(ui_->push_button_load_mesh, &QPushButton::clicked, this, &TPPWidget::onLoadMesh);
-  connect(ui_->push_button_load_configuration, &QPushButton::clicked, this, &TPPWidget::onLoadConfiguration);
-  connect(ui_->push_button_save_configuration, &QPushButton::clicked, this, &TPPWidget::onSaveConfiguration);
   connect(ui_->check_box_show_original_mesh, &QCheckBox::clicked, this, &TPPWidget::onShowOriginalMesh);
   connect(ui_->check_box_show_modified_mesh, &QCheckBox::clicked, this, &TPPWidget::onShowModifiedMesh);
   connect(ui_->check_box_show_original_tool_path, &QCheckBox::clicked, this, &TPPWidget::onShowUnmodifiedToolPath);
@@ -160,69 +159,7 @@ void TPPWidget::onLoadMesh(const bool /*checked*/)
     setMeshFile(file);
 }
 
-void TPPWidget::setConfigurationFile(const QString& file)
-{
-  ui_->line_edit_configuration->setText(file);
-
-  try
-  {
-    pipeline_widget_->configure(YAML::LoadFile(file.toStdString()));
-  }
-  catch (const YAML::BadFile&)
-  {
-    QString message;
-    QTextStream ss;
-    ss << "Failed to open YAML file at '" << file << "'";
-    QMessageBox::warning(this, "Configuration Error", message);
-  }
-  catch (const std::exception& ex)
-  {
-    std::stringstream ss;
-    printException(ex, ss);
-    QMessageBox::warning(this, "Configuration Error", QString::fromStdString(ss.str()));
-  }
-}
-
-void TPPWidget::onLoadConfiguration(const bool /*checked*/)
-{
-  QString file = ui_->line_edit_configuration->text();
-  if (file.isEmpty())
-    file = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
-
-  file = QFileDialog::getOpenFileName(this, "Load configuration file", file, "YAML files (*.yaml)");
-  if (!file.isEmpty())
-    setConfigurationFile(file);
-}
-
-void TPPWidget::onSaveConfiguration(const bool /*checked*/)
-{
-  try
-  {
-    QString file = ui_->line_edit_configuration->text();
-    if (file.isEmpty())
-      file = QStandardPaths::standardLocations(QStandardPaths::HomeLocation).at(0);
-
-    file = QFileDialog::getSaveFileName(this, "Save configuration file", file, "YAML files (*.yaml)");
-    if (file.isEmpty())
-      return;
-
-    YAML::Node config;
-    pipeline_widget_->save(config);
-
-    std::ofstream ofh(file.toStdString());
-    if (!ofh)
-      throw std::runtime_error("Failed to open output file at '" + file.toStdString() + "'");
-
-    ofh << config;
-    QMessageBox::information(this, "Configuration", "Successfully saved tool path planning pipeline configuration");
-  }
-  catch (const std::exception& ex)
-  {
-    std::stringstream ss;
-    printException(ex, ss);
-    QMessageBox::warning(this, "Save Error", QString::fromStdString(ss.str()));
-  }
-}
+void TPPWidget::setConfigurationFile(const QString& file) { pipeline_widget_->setConfigurationFile(file); }
 
 vtkSmartPointer<vtkTransform> toVTK(const Eigen::Isometry3d& mat)
 {
@@ -297,7 +234,7 @@ void TPPWidget::onPlan(const bool /*checked*/)
     if (pcl::io::loadPolygonFile(mesh_file, full_mesh) < 1)
       throw std::runtime_error("Failed to load mesh from file");
 
-    const ToolPathPlannerPipeline pipeline = pipeline_widget_->createPipeline();
+    const ToolPathPlannerPipeline pipeline = pipeline_widget_->pipeline_widget->createPipeline();
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
     // Run the mesh modifier

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -234,7 +234,7 @@ void TPPWidget::onPlan(const bool /*checked*/)
     if (pcl::io::loadPolygonFile(mesh_file, full_mesh) < 1)
       throw std::runtime_error("Failed to load mesh from file");
 
-    const ToolPathPlannerPipeline pipeline = pipeline_widget_->pipeline_widget->createPipeline();
+    const ToolPathPlannerPipeline pipeline = pipeline_widget_->createPipeline();
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
     // Run the mesh modifier

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -48,7 +48,7 @@ TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
 {
   ui_->setupUi(this);
 
-  ui_->scroll_area->setWidget(pipeline_widget_);
+  overwriteWidget(ui_->group_box_configuration->layout(), ui_->widget, pipeline_widget_);
   ui_->splitter->addWidget(render_widget_);
 
   // Set up the VTK objects

--- a/noether_gui/ui/configurable_tpp_pipeline_widget.ui
+++ b/noether_gui/ui/configurable_tpp_pipeline_widget.ui
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigurableTPPPipeline</class>
+ <widget class="QWidget" name="ConfigurableTPPPipeline">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>79</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="line_edit"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="push_button_load">
+       <property name="text">
+        <string>Load</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QPushButton" name="push_button_save">
+     <property name="text">
+      <string>Save</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/noether_gui/ui/plugin_loader_widget.ui
+++ b/noether_gui/ui/plugin_loader_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>340</width>
+    <height>159</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,23 +47,24 @@
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="vertical_layout_plugins"/>
+       <widget class="QScrollArea" name="scroll_area">
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="contents">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>296</width>
+           <height>68</height>
+          </rect>
+         </property>
+        </widget>
+       </widget>
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/noether_gui/ui/tpp_pipeline_widget.ui
+++ b/noether_gui/ui/tpp_pipeline_widget.ui
@@ -61,9 +61,29 @@
          <property name="title">
           <string/>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QWidget" name="widget_tpp" native="true"/>
+           <widget class="QScrollArea" name="scroll_area">
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="widgetResizable">
+             <bool>true</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            </property>
+            <widget class="QWidget" name="widget_tpp">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>364</width>
+               <height>289</height>
+              </rect>
+             </property>
+            </widget>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/noether_gui/ui/tpp_widget.ui
+++ b/noether_gui/ui/tpp_widget.ui
@@ -63,31 +63,6 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLineEdit" name="line_edit_configuration">
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="push_button_load_configuration">
-              <property name="text">
-               <string>Load</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QPushButton" name="push_button_save_configuration">
-            <property name="text">
-             <string>Save</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QScrollArea" name="scroll_area">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
@@ -113,7 +88,7 @@
                <x>0</x>
                <y>0</y>
                <width>1024</width>
-               <height>220</height>
+               <height>278</height>
               </rect>
              </property>
             </widget>
@@ -211,9 +186,6 @@
  <tabstops>
   <tabstop>line_edit_mesh</tabstop>
   <tabstop>push_button_load_mesh</tabstop>
-  <tabstop>line_edit_configuration</tabstop>
-  <tabstop>push_button_load_configuration</tabstop>
-  <tabstop>push_button_save_configuration</tabstop>
   <tabstop>scroll_area</tabstop>
   <tabstop>push_button_plan</tabstop>
   <tabstop>double_spin_box_axis_size</tabstop>

--- a/noether_gui/ui/tpp_widget.ui
+++ b/noether_gui/ui/tpp_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1070</width>
-    <height>614</height>
+    <width>215</width>
+    <height>344</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -63,36 +63,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <widget class="QScrollArea" name="scroll_area">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>1024</height>
-             </size>
-            </property>
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="widgetResizable">
-             <bool>true</bool>
-            </property>
-            <widget class="QWidget" name="content">
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>0</y>
-               <width>1024</width>
-               <height>278</height>
-              </rect>
-             </property>
-            </widget>
-           </widget>
+           <widget class="QWidget" name="widget" native="true"/>
           </item>
           <item>
            <widget class="QPushButton" name="push_button_plan">
@@ -186,7 +157,6 @@
  <tabstops>
   <tabstop>line_edit_mesh</tabstop>
   <tabstop>push_button_load_mesh</tabstop>
-  <tabstop>scroll_area</tabstop>
   <tabstop>push_button_plan</tabstop>
   <tabstop>double_spin_box_axis_size</tabstop>
   <tabstop>check_box_show_original_mesh</tabstop>


### PR DESCRIPTION
This PR adds a `ConfigurableTPPPipelineWidget` for use in downstream applications and includes the existing `TPPPipelineWidget` as well as the buttons for loading and saving configurations to YAML file. It also updates the TPP application to use this configurable TPP pipeline widget internally