### PR TITLE
Show tool path as polyline

### DIFF
--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -39,6 +39,12 @@ namespace noether
 {
 class ConfigurableTPPPipelineWidget;
 
+enum class LineStyle{  
+  INTRA_SEGMENT = 0, /*@brief between waypoints in a segment*/
+  INTER_SEGMENT, /*@brief between tool path segments*/
+  INTER_PATH, /*@brief between tool paths*/
+};
+
 /**
  * @brief Basic tool path planning widget
  * @details Allows the user to laod a mesh from file, configure a tool path planning pipeline, and generate tool paths

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -39,10 +39,11 @@ namespace noether
 {
 class ConfigurableTPPPipelineWidget;
 
-enum class LineStyle{  
+enum class LineStyle
+{
   INTRA_SEGMENT = 0, /*@brief between waypoints in a segment*/
-  INTER_SEGMENT, /*@brief between tool path segments*/
-  INTER_PATH, /*@brief between tool paths*/
+  INTER_SEGMENT,     /*@brief between tool path segments*/
+  INTER_PATH,        /*@brief between tool paths*/
 };
 
 /**

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -66,7 +66,9 @@ private:
   void onShowOriginalMesh(const bool);
   void onShowModifiedMesh(const bool);
   void onShowUnmodifiedToolPath(const bool);
+  void onShowUnmodifiedConnectedPath(const bool);
   void onShowModifiedToolPath(const bool);
+  void onShowModifiedConnectedPath(const bool);
 
   Ui::TPP* ui_;
   ConfigurableTPPPipelineWidget* pipeline_widget_;
@@ -78,7 +80,9 @@ private:
   vtkSmartPointer<vtkActor> mesh_actor_;
 
   vtkSmartPointer<vtkAssembly> tool_path_actor_;
+  vtkSmartPointer<vtkAssembly> connected_path_actor_;
   vtkSmartPointer<vtkAssembly> unmodified_tool_path_actor_;
+  vtkSmartPointer<vtkAssembly> unmodified_connected_path_actor_;
   vtkSmartPointer<vtkAssembly> mesh_fragment_actor_;
 
   vtkSmartPointer<vtkAxes> axes_;

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -332,7 +332,7 @@ vtkSmartPointer<vtkAssembly> createToolPathPolylineActor(const std::vector<ToolP
         const Eigen::Isometry3d& w1 = tool_path.back().back();
         const Eigen::Isometry3d& w2 = next_tool_path.front().front();
 
-        auto actor = createLineActor(w1, w2, LineStyle::INTER_PATH);     
+        auto actor = createLineActor(w1, w2, LineStyle::INTER_PATH);
         assembly->AddPart(actor);
       }
     }

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -238,7 +238,7 @@ vtkSmartPointer<vtkAssembly> createToolPathActors(const std::vector<ToolPaths>& 
 
 vtkSmartPointer<vtkActor> createLineActor(const Eigen::Isometry3d& point1,
                                           const Eigen::Isometry3d& point2,
-                                          int lineStyle)
+                                          LineStyle lineStyle)
 {
   vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
   points->InsertNextPoint(point1.translation().data());
@@ -265,15 +265,15 @@ vtkSmartPointer<vtkActor> createLineActor(const Eigen::Isometry3d& point1,
 
   switch (lineStyle)
   {
-    case 0:
+    case LineStyle::INTRA_SEGMENT:
       property->SetLineWidth(3.0);
       property->SetColor(0.27, 0.74, 0.2);
       break;
-    case 1:
+    case LineStyle::INTER_SEGMENT:
       property->SetLineWidth(1.0);
       property->SetColor(1, 0.8, 0);
       break;
-    case 2:
+    case LineStyle::INTER_PATH:
       property->SetLineWidth(0.5);
       property->SetColor(1, 0.271, 0.043);
       break;
@@ -311,7 +311,7 @@ vtkSmartPointer<vtkAssembly> createToolPathPolylineActor(const std::vector<ToolP
           const Eigen::Isometry3d& point = segment[k];
           const Eigen::Isometry3d& next_point = segment[k + 1];
 
-          auto actor = createLineActor(point, next_point, 0);
+          auto actor = createLineActor(point, next_point, LineStyle::INTRA_SEGMENT);
           assembly->AddPart(actor);
         }
 
@@ -321,7 +321,7 @@ vtkSmartPointer<vtkAssembly> createToolPathPolylineActor(const std::vector<ToolP
           const Eigen::Isometry3d& w1 = segment.back();
           const Eigen::Isometry3d& w2 = next_segment.front();
 
-          auto actor = createLineActor(w1, w2, 1);
+          auto actor = createLineActor(w1, w2, LineStyle::INTER_SEGMENT);
           assembly->AddPart(actor);
         }
       }
@@ -332,7 +332,7 @@ vtkSmartPointer<vtkAssembly> createToolPathPolylineActor(const std::vector<ToolP
         const Eigen::Isometry3d& w1 = tool_path.back().back();
         const Eigen::Isometry3d& w2 = next_tool_path.front().front();
 
-        auto actor = createLineActor(w1, w2, 2);
+        auto actor = createLineActor(w1, w2, LineStyle::INTER_PATH);     
         assembly->AddPart(actor);
       }
     }

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -124,29 +124,29 @@ void TPPWidget::onShowOriginalMesh(const bool checked)
 void TPPWidget::onShowModifiedMesh(const bool checked)
 {
   mesh_fragment_actor_->SetVisibility(checked);
-
-  render_widget_->renderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
 }
 
 void TPPWidget::onShowUnmodifiedConnectedPath(const bool checked)
 {
   unmodified_connected_path_actor_->SetVisibility(checked);
-
-  render_widget_->renderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
 }
 
 void TPPWidget::onShowUnmodifiedToolPath(const bool checked)
 {
   unmodified_tool_path_actor_->SetVisibility(checked);
-
-  render_widget_->renderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
 }
 
 void TPPWidget::onShowModifiedConnectedPath(const bool checked)
 {
   connected_path_actor_->SetVisibility(checked);
-
-  render_widget_->renderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
+  render_widget_->GetRenderWindow()->Render();
 }
 
 void TPPWidget::onShowModifiedToolPath(const bool checked)
@@ -402,7 +402,9 @@ void TPPWidget::onPlan(const bool /*checked*/)
       connected_path_actor_->SetVisibility(ui_->check_box_show_modified_connected_path->isChecked());
     }
 
-    render_widget_->renderWindow()->Render();
+    // Call render twice
+    render_widget_->GetRenderWindow()->Render();
+    render_widget_->GetRenderWindow()->Render();
   }
   catch (const std::exception& ex)
   {

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -89,9 +89,9 @@ TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
   mesh_actor_->SetVisibility(ui_->check_box_show_original_mesh->isChecked());
   mesh_fragment_actor_->SetVisibility(ui_->check_box_show_modified_mesh->isChecked());
   unmodified_tool_path_actor_->SetVisibility(ui_->check_box_show_original_tool_path->isChecked());
-  unmodified_connected_path_actor_->SetVisibility(!ui_->check_box_show_original_connected_path->isChecked());
+  unmodified_connected_path_actor_->SetVisibility(ui_->check_box_show_original_connected_path->isChecked());
   tool_path_actor_->SetVisibility(ui_->check_box_show_modified_tool_path->isChecked());
-  connected_path_actor_->SetVisibility(!ui_->check_box_show_modified_connected_path->isChecked());
+  connected_path_actor_->SetVisibility(ui_->check_box_show_modified_connected_path->isChecked());
 
   // Connect signals
   connect(ui_->push_button_load_mesh, &QPushButton::clicked, this, &TPPWidget::onLoadMesh);
@@ -378,7 +378,7 @@ void TPPWidget::onPlan(const bool /*checked*/)
       renderer_->RemoveActor(unmodified_connected_path_actor_);
       unmodified_connected_path_actor_ = createToolPathPolylineActor(unmodified_tool_paths, tube_filter_->GetOutputPort());
       renderer_->AddActor(unmodified_connected_path_actor_);
-      unmodified_connected_path_actor_->SetVisibility(!ui_->check_box_show_original_tool_path->isChecked());
+      unmodified_connected_path_actor_->SetVisibility(ui_->check_box_show_original_connected_path->isChecked());
     }
 
     // Render the modified tool paths
@@ -394,7 +394,7 @@ void TPPWidget::onPlan(const bool /*checked*/)
       renderer_->RemoveActor(connected_path_actor_);
       connected_path_actor_ = createToolPathPolylineActor(tool_paths_, tube_filter_->GetOutputPort());
       renderer_->AddActor(connected_path_actor_);
-      connected_path_actor_->SetVisibility(!ui_->check_box_show_modified_tool_path->isChecked());
+      connected_path_actor_->SetVisibility(ui_->check_box_show_modified_connected_path->isChecked());
     }
 
     

--- a/noether_gui/ui/tpp_widget.ui
+++ b/noether_gui/ui/tpp_widget.ui
@@ -129,21 +129,92 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="check_box_show_original_tool_path">
-            <property name="text">
-             <string>Show Original Tool Path</string>
-            </property>
-           </widget>
+            <layout class="QHBoxLayout" name="horizontalLayout_originalToolPath">
+              <item>
+                <widget class="QLabel" name="label_4">
+                  <property name="text">
+                    <string>Original Tool Path:</string>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QCheckBox" name="check_box_show_original_tool_path">
+                    <property name="text">
+                      <string>Show Points</string>
+                    </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QCheckBox" name="check_box_show_original_connected_path">
+                    <property name="text">
+                      <string>Show Line</string>
+                    </property>
+                </widget>
+              </item>
+              <item>
+              <spacer>
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                  <enum>QSizePolicy::Expanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                  <size>
+                    <width>0</width>
+                    <height>0</height>
+                  </size>
+                </property>
+              </spacer>
+              </item>
+            </layout>
           </item>
           <item>
-           <widget class="QCheckBox" name="check_box_show_modified_tool_path">
-            <property name="text">
-             <string>Show Modified Tool Path</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
+          <layout class="QHBoxLayout" name="horizonalLayout_modifiedToolPath">
+            <item>
+              <widget class="QLabel" name="label_3">
+                <property name="text">
+                  <string>Modified Tool Path:</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QCheckBox" name="check_box_show_modified_tool_path">
+                <property name="text">
+                  <string>Show Points</string>
+                </property>
+                <property name="checked">
+                  <bool>true</bool>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QCheckBox" name="check_box_show_modified_connected_path">
+                <property name="text">
+                  <string>Show Line</string>
+                </property>
+                <property name="checked">
+                  <bool>true</bool>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <spacer>
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                  <enum>QSizePolicy::Expanding</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                  <size>
+                    <width>0</width>
+                    <height>0</height>
+                  </size>
+                </property>
+              </spacer>
+            </item>
+          </layout>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
1. Compile noether and run the gui

The gui viewer should look like this:
![Screenshot from 2024-04-25 10-44-42](https://github.com/ros-industrial/noether/assets/167059981/ed2c5c94-3cac-442a-95b6-6064e0ae33f9)

2. Import an object and plan a path with an additional tool path modifier
3. The modified tool path with points and line should be visible