### PR TITLE
Multi tool path planner

### DIFF
--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(${PROJECT_NAME} SHARED
   src/tool_path_modifiers/uniform_orientation_modifier.cpp
   src/tool_path_modifiers/offset_modifier.cpp
   # Tool Path Planners
+  src/tool_path_planners/multi_tool_path_planner.cpp
   src/tool_path_planners/edge/edge_planner.cpp
   src/tool_path_planners/raster/raster_planner.cpp
   src/tool_path_planners/raster/origin_generators/aabb_origin_generator.cpp

--- a/noether_tpp/include/noether_tpp/tool_path_planners/multi_tool_path_planner.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/multi_tool_path_planner.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <noether_tpp/core/tool_path_planner.h>
+
+namespace noether
+{
+/**
+ * @brief Runs multiple tool path planners serially and concatenates their outputs together
+ */
+class MultiToolPathPlanner : public ToolPathPlanner
+{
+public:
+  MultiToolPathPlanner(MultiToolPathPlanner&&) = delete;
+  MultiToolPathPlanner(const MultiToolPathPlanner&) = delete;
+
+  MultiToolPathPlanner& operator=(const MultiToolPathPlanner&) = delete;
+  MultiToolPathPlanner& operator=(MultiToolPathPlanner&&) = delete;
+
+  explicit MultiToolPathPlanner(std::vector<ToolPathPlanner::ConstPtr>&& planners);
+
+  ToolPaths plan(const pcl::PolygonMesh& mesh) const override;
+
+protected:
+  const std::vector<ToolPathPlanner::ConstPtr> planners_;
+};
+
+}  // namespace noether

--- a/noether_tpp/src/tool_path_planners/multi_tool_path_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/multi_tool_path_planner.cpp
@@ -1,0 +1,21 @@
+#include <noether_tpp/tool_path_planners/multi_tool_path_planner.h>
+
+namespace noether
+{
+MultiToolPathPlanner::MultiToolPathPlanner(std::vector<ToolPathPlanner::ConstPtr>&& planners)
+  : planners_(std::move(planners))
+{
+}
+
+ToolPaths MultiToolPathPlanner::plan(const pcl::PolygonMesh& mesh) const
+{
+  ToolPaths output;
+  for (const ToolPathPlanner::ConstPtr& planner : planners_)
+  {
+    ToolPaths tool_paths = planner->plan(mesh);
+    output.insert(output.end(), tool_paths.begin(), tool_paths.end());
+  }
+  return output;
+}
+
+}  // namespace noether


### PR DESCRIPTION
This PR adds a tool path planner class that can run multiple tool path planners in a sequence and concatenate their output. This feature supports more complex tool path planning tasks (e.g., cross-hatch rastering) in a modular way