### PR TITLE
GUI Updates

### DIFF
--- a/noether_gui/include/noether_gui/widgets/tool_path_planners/raster/raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_planners/raster/raster_planner_widget.h
@@ -29,9 +29,6 @@ protected:
   DirectionGeneratorWidget* getDirectionGeneratorWidget() const;
   OriginGeneratorWidget* getOriginGeneratorWidget() const;
 
-  void setDirectionGeneratorWidget(const QString& plugin_name, const YAML::Node& config);
-  void setOriginGeneratorWidget(const QString& plugin_name, const YAML::Node& config);
-
   const boost_plugin_loader::PluginLoader loader_;
   Ui::RasterPlanner* ui_;
 };

--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -96,7 +96,6 @@ void ConfigurableTPPPipelineWidget::onSaveConfiguration(const bool /*checked*/)
       throw std::runtime_error("Failed to open output file at '" + file.toStdString() + "'");
 
     ofh << config;
-    QMessageBox::information(this, "Configuration", "Successfully saved tool path planning pipeline configuration");
   }
   catch (const std::exception& ex)
   {

--- a/noether_gui/ui/raster_planner_widget.ui
+++ b/noether_gui/ui/raster_planner_widget.ui
@@ -29,16 +29,6 @@
          <item>
           <widget class="QComboBox" name="combo_box_dir_gen"/>
          </item>
-         <item>
-          <widget class="QToolButton" name="tool_button_dir_gen">
-           <property name="text">
-            <string>...</string>
-           </property>
-           <property name="icon">
-            <iconset theme="list-add"/>
-           </property>
-          </widget>
-         </item>
         </layout>
        </item>
        <item>
@@ -49,16 +39,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="group_box_dir_gen">
-         <property name="title">
-          <string/>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <widget class="QWidget" name="widget_dir_gen" native="true"/>
-          </item>
-         </layout>
-        </widget>
+        <widget class="QStackedWidget" name="stacked_widget_dir_gen"/>
        </item>
       </layout>
      </widget>
@@ -72,16 +53,6 @@
          <item>
           <widget class="QComboBox" name="combo_box_origin_gen"/>
          </item>
-         <item>
-          <widget class="QToolButton" name="tool_button_origin_gen">
-           <property name="text">
-            <string>...</string>
-           </property>
-           <property name="icon">
-            <iconset theme="list-add"/>
-           </property>
-          </widget>
-         </item>
         </layout>
        </item>
        <item>
@@ -92,16 +63,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="group_box_origin_gen">
-         <property name="title">
-          <string/>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_6">
-          <item>
-           <widget class="QWidget" name="widget_origin_gen" native="true"/>
-          </item>
-         </layout>
-        </widget>
+        <widget class="QStackedWidget" name="stacked_widget_origin_gen"/>
        </item>
       </layout>
      </widget>

--- a/noether_gui/ui/tpp_pipeline_widget.ui
+++ b/noether_gui/ui/tpp_pipeline_widget.ui
@@ -51,59 +51,32 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QComboBox" name="combo_box_tpp"/>
-         </item>
-         <item>
-          <widget class="QToolButton" name="tool_button_select_tpp">
-           <property name="text">
-            <string>...</string>
-           </property>
-           <property name="icon">
-            <iconset theme="list-add"/>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QComboBox" name="combo_box_tpp"/>
        </item>
        <item>
-        <widget class="Line" name="line">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="widgetResizable">
+          <bool>true</bool>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="group_box_tpp">
-         <property name="title">
-          <string/>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QScrollArea" name="scroll_area">
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="widgetResizable">
-             <bool>true</bool>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignHCenter|Qt::AlignTop</set>
-            </property>
-            <widget class="QWidget" name="widget_tpp">
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>0</y>
-               <width>382</width>
-               <height>301</height>
-              </rect>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>406</width>
+            <height>339</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <widget class="QStackedWidget" name="stacked_widget">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
              </property>
             </widget>
-           </widget>
-          </item>
-         </layout>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>

--- a/noether_gui/ui/tpp_widget.ui
+++ b/noether_gui/ui/tpp_widget.ui
@@ -306,6 +306,9 @@
    <property name="toolTip">
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show tool path lines &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;before&lt;/span&gt; modification step&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+L</string>
+   </property>
   </action>
   <action name="action_show_modified_tool_path_lines">
    <property name="checkable">
@@ -316,6 +319,9 @@
    </property>
    <property name="toolTip">
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show tool path lines &lt;span style=&quot; font-weight:700; font-style:italic;&quot;&gt;after&lt;/span&gt; modification step&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This PR updates the raster tool path planner widgets to load all origin and direction generator widgets on creation and switch between them using a stacked widget and combo box. It also updates the TPP pipeline widget in a similar way for the tool path planner widgets. This should make it more convenient to switch back and forth between planners without losing the configuration values each time