### PR TITLE
Update tool drag tool path modifier behavior

### DIFF
--- a/noether_tpp/src/tool_path_modifiers/tool_drag_orientation_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/tool_drag_orientation_modifier.cpp
@@ -23,8 +23,9 @@ ToolPaths ToolDragOrientationToolPathModifier::modify(ToolPaths tool_paths) cons
     {
       for (Eigen::Isometry3d& waypoint : segment)
       {
-        waypoint.rotate(Eigen::AngleAxisd(sign * -angle_offset_, Eigen::Vector3d::UnitY()))
-            .translate(Eigen::Vector3d(sign * tool_radius_, 0, 0));
+        double z_offset = tool_radius_ * std::sin(angle_offset_);
+        waypoint.translate(Eigen::Vector3d(0.0, 0.0, z_offset))
+            .rotate(Eigen::AngleAxisd(sign * -angle_offset_, Eigen::Vector3d::UnitY()));
       }
     }
   }


### PR DESCRIPTION
This PR updates the tool drag tool path modifier behavior to *not* offset the tool path by the media radius in the direction of travel as shown in the diagrams below. The current behavior (intended for cutting and grinding applications) does not perform quite as well in practice, even though it puts the edge of the tool radius directly on the input tool path waypoints. 

## Current behavior
![before](https://github.com/user-attachments/assets/20be0cc4-8e96-4f41-8ff3-62a6e2cf30c0)

## Proposed behavior
![after](https://github.com/user-attachments/assets/ca5d47fd-790d-48e9-a5ce-6ffbcccdfb30)
