### PR TITLE
Installed executables for access by ROS

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -130,3 +130,6 @@ configure_package(
     "Qt5 REQUIRED COMPONENTS Widgets"
     yaml-cpp
 )
+
+# Install the executable(s) for access by ROS
+install(TARGETS ${PROJECT_NAME}_app DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
Addresses #234, #241 by installing the executable(s) in a location accessible by `ros2 run` and `rosrun`