### PR TITLE
Fully support direction generator in plane slicer raster planner 

### DIFF
--- a/noether_gui/include/noether_gui/widgets/tool_path_planners/raster/plane_slicer_raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_planners/raster/plane_slicer_raster_planner_widget.h
@@ -3,6 +3,7 @@
 #include <noether_gui/widgets/tool_path_planners/raster/raster_planner_widget.h>
 
 class QDoubleSpinBox;
+class QCheckBox;
 
 namespace noether
 {
@@ -19,6 +20,7 @@ public:
 protected:
   QDoubleSpinBox* search_radius_;
   QDoubleSpinBox* min_segment_size_;
+  QCheckBox* bidirectional_;
 };
 
 }  // namespace noether

--- a/noether_gui/src/widgets/tool_path_planners/raster/raster_planner_widget.ui
+++ b/noether_gui/src/widgets/tool_path_planners/raster/raster_planner_widget.ui
@@ -85,8 +85,11 @@
        <layout class="QFormLayout" name="form_layout">
         <item row="0" column="0">
          <widget class="QLabel" name="label_line_spacing">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance between raster lines&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="text">
-           <string>Line Spacing</string>
+           <string>Line Spacing (m)</string>
           </property>
          </widget>
         </item>
@@ -124,15 +127,21 @@
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_point_spacing">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance between tool path waypoints on a raster line&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="text">
-           <string>Point Spacing</string>
+           <string>Point Spacing (m)</string>
           </property>
          </widget>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_min_hole_size">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The size of the smallest hole that the tool path planner should not jump over&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="text">
-           <string>Minimum Hole Size</string>
+           <string>Minimum Hole Size (m)</string>
           </property>
          </widget>
         </item>

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/plane_slicer_raster_planner.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/plane_slicer_raster_planner.h
@@ -25,6 +25,9 @@ namespace noether
 /**
  * @brief An implementation of the Raster Planner using a series of parallel cutting planes.
  * This implementation works best on approximately planar parts.
+ * The direction generator defines the direction of the raster cut.
+ * The cut normal (i.e., the raster step direction) is defined by the cross product of the cut direction and the
+ * smallest principal axis of the mesh.
  */
 class PlaneSlicerRasterPlanner : public RasterPlanner
 {
@@ -33,6 +36,7 @@ public:
 
   void setSearchRadius(const double search_radius);
   void setMinSegmentSize(const double min_segment_size);
+  void generateRastersBidirectionally(const bool bidirectional);
 
 protected:
   /**
@@ -42,7 +46,9 @@ protected:
    */
   ToolPaths planImpl(const pcl::PolygonMesh& mesh) const;
 
-private:
+  /** @brief Flag indicating whether rasters should be generated in the direction of both the cut normal and its
+   * negation */
+  bool bidirectional_ = true;
   /** @brief Minimum length of valid segment (m) */
   double min_segment_size_;
   /** @brief Search radius for calculating normals (m) */

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/raster_planner.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/raster_planner.h
@@ -26,8 +26,11 @@
 namespace noether
 {
 /**
- * @brief Interface for various methods to generate the direction of raster paths.  The direction
- * generated will move along the line from the first point to the second, then third, etc.
+ * @brief Interface for generating the direction of raster paths. This direction represents the line along which
+ * waypoints in a raster path will lie.
+ * @details This interface only defines the raster path direction. It is overconstrained to also define the raster step
+ * direction, which is typically normal to the raster path direction. As such, we leave it up to the individual raster
+ * planners to determine how propagate sequential rasters normal to the path direction.
  */
 struct DirectionGenerator
 {


### PR DESCRIPTION
The concept of the nominal raster planner is that the user specifies a location where the first raster is made and the direction along which that raster "cuts" the mesh. The direction along which subsequent rasters should step to cover the full surface is left up to the individual planners but is likely to be in a directional orthogonal to the raster "cut" direction and orthogonal to the nominal surface normal.

The plane slicer raster planner calculates the step direction (i.e., cut plane normal) by taking the cross product of the raster "cut" direction with the smallest principal axis of the mesh. Instead of only stepping along this direction (starting at the specified cut origin), the current plane slicer raster planner generates rasters both forward in the direction of the cut plane normal and backwards against the cut plane normal. This is problematic for some use-cases where you might want to start the rasters at a specific location and only step in a single specified direction.

This PR adds a flag to the plane slicer raster planner to enable the generation of rasters both aligned with and against the cut plane normal (i.e., bidirectionally). You can also think of this change as enabling the generation of rasters only in the direction aligned with the cut plane normal.

This PR also updates the raster planner UIs with tool tip information and units on specified values

Builds on #255; addresses #242

## Unidirectional (cut origin at mesh centroid)
![image](https://github.com/user-attachments/assets/7f79869f-90f3-4e9d-ad38-45f609ec7d9a)

## Bidrectional (cut origin at mesh centroid)
![image](https://github.com/user-attachments/assets/c70a5e01-eaf8-4f40-b679-597f6a2560c1)