### PR TITLE
Fix issue with eigen size mismatch in doing calculation

### DIFF
--- a/noether_tpp/src/mesh_modifiers/subset_extraction/extruded_polygon_subset_extractor.cpp
+++ b/noether_tpp/src/mesh_modifiers/subset_extraction/extruded_polygon_subset_extractor.cpp
@@ -67,16 +67,8 @@ bool clusterComparator(const pcl::PointIndices& a,
     pcl::PointCloud<pcl::PointXYZ> index_cloud;
     extract.filter(index_cloud);
 
-    Eigen::MatrixXf points_matrix = index_cloud.getMatrixXfMap(3, 4, 0);
-
-    // Subtract the centroid from each point
-    Eigen::MatrixXf centered = points_matrix.colwise() - boundary_centroid;
-
-    // Compute the mean of the centered points
-    Eigen::Vector3f mean_vector = centered.rowwise().mean();
-
-    // Compute the norm of the mean vector
-    float avg_dist = mean_vector.norm();
+    float avg_dist =
+            (index_cloud.getMatrixXfMap(3, 4, 0).colwise() - boundary_centroid).rowwise().mean().norm();
 
     dist.push_back(avg_dist);
   }

--- a/noether_tpp/src/mesh_modifiers/subset_extraction/extruded_polygon_subset_extractor.cpp
+++ b/noether_tpp/src/mesh_modifiers/subset_extraction/extruded_polygon_subset_extractor.cpp
@@ -67,8 +67,7 @@ bool clusterComparator(const pcl::PointIndices& a,
     pcl::PointCloud<pcl::PointXYZ> index_cloud;
     extract.filter(index_cloud);
 
-    float avg_dist =
-            (index_cloud.getMatrixXfMap(3, 4, 0).colwise() - boundary_centroid).rowwise().mean().norm();
+    float avg_dist = (index_cloud.getMatrixXfMap(3, 4, 0).colwise() - boundary_centroid).rowwise().mean().norm();
 
     dist.push_back(avg_dist);
   }

--- a/noether_tpp/src/mesh_modifiers/subset_extraction/extruded_polygon_subset_extractor.cpp
+++ b/noether_tpp/src/mesh_modifiers/subset_extraction/extruded_polygon_subset_extractor.cpp
@@ -67,8 +67,17 @@ bool clusterComparator(const pcl::PointIndices& a,
     pcl::PointCloud<pcl::PointXYZ> index_cloud;
     extract.filter(index_cloud);
 
-    float avg_dist =
-        (index_cloud.getMatrixXfMap(3, 4, 0).rowwise() - boundary_centroid.transpose()).colwise().mean().norm();
+    Eigen::MatrixXf points_matrix = index_cloud.getMatrixXfMap(3, 4, 0);
+
+    // Subtract the centroid from each point
+    Eigen::MatrixXf centered = points_matrix.colwise() - boundary_centroid;
+
+    // Compute the mean of the centered points
+    Eigen::Vector3f mean_vector = centered.rowwise().mean();
+
+    // Compute the norm of the mean vector
+    float avg_dist = mean_vector.norm();
+
     dist.push_back(avg_dist);
   }
 


### PR DESCRIPTION
When more than one clusters were being created this would result in a segfault because the comparator actually had to do calculations.

The error I was getting looked like this:
```
[rviz2-1] rviz2: /usr/include/eigen3/Eigen/src/Core/CwiseBinaryOp.h:116: Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>::CwiseBinaryOp(const Lhs&, const Rhs&, const BinaryOp&) [with BinaryOp = Eigen::internal::scalar_difference_op<float, float>; LhsType = const Eigen::Map<Eigen::Matrix<float, -1, -1>, 16, Eigen::OuterStride<> >; RhsType = const Eigen::Replicate<Eigen::Transpose<const Eigen::Matrix<float, 3, 1> >, -1, 1>; Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>::Lhs = Eigen::Map<Eigen::Matrix<float, -1, -1>, 16, Eigen::OuterStride<> >; Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>::Rhs = Eigen::Replicate<Eigen::Transpose<const Eigen::Matrix<float, 3, 1> >, -1, 1>]: Assertion `aLhs.rows() == aRhs.rows() && aLhs.cols() == aRhs.cols()' failed.
```