### PR TITLE
Maintain backwards compatibility for TPP config files with bidirectional parameter for plane slice raster planner

### DIFF
--- a/noether_gui/src/widgets/tool_path_planners/raster/plane_slicer_raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_planners/raster/plane_slicer_raster_planner_widget.cpp
@@ -49,7 +49,15 @@ void PlaneSlicerRasterPlannerWidget::configure(const YAML::Node& config)
   RasterPlannerWidget::configure(config);
   search_radius_->setValue(getEntry<double>(config, "search_radius"));
   min_segment_size_->setValue(getEntry<double>(config, "min_segment_size"));
-  bidirectional_->setChecked(getEntry<bool>(config, "bidirectional"));
+
+  // Optionally get bidirectional parameter to maintain backwards compatibility
+  try
+  {
+    bidirectional_->setChecked(getEntry<bool>(config, "bidirectional"));
+  }
+  catch (const std::exception& ex)
+  {
+  }
 }
 
 void PlaneSlicerRasterPlannerWidget::save(YAML::Node& config) const


### PR DESCRIPTION
Changes per commit message to maintain backwards compatibility with TPP configuration files that may not include the new `bi-directional` parameter