### PR TITLE
Fix plugin loader widget

### DIFF
--- a/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
+++ b/noether_gui/include/noether_gui/widgets/plugin_loader_widget.h
@@ -23,6 +23,7 @@ class PluginLoaderWidget : public QWidget
 {
 public:
   PluginLoaderWidget(boost_plugin_loader::PluginLoader loader, const QString& title, QWidget* parent = nullptr);
+  ~PluginLoaderWidget();
 
   QWidgetList getWidgets() const;
 
@@ -36,6 +37,13 @@ private:
   void shiftCurrentWidget(const int offset);
 
   Ui::PluginLoader* ui_;
+
+  /**
+   * @brief Container for holding all loaded plugins
+   * @details All loaded plugins must be held in scope in order to prevent the plugin libraries from being unloaded
+   */
+  std::set<std::shared_ptr<PluginT>> plugins_;
+
   const boost_plugin_loader::PluginLoader loader_;
 };
 


### PR DESCRIPTION
Recently I ran into an issue where I created a `noether_gui` plugin in a library outside of this repo, the GUI was able to load it, but then it would segfault when trying to display the widget created by the plugin. It turns out that `boost_plugin_loader` requires plugin objects to remain in scope as long as that plugin (and any object created by it) are being used. When the plugin is destroyed, the library providing its functionality is unloaded.

In the case of the plugin loader widget in this repository, we are currently loading a plugin, creating a widget from it, and then destroying the plugin, which causes the plugin's library to be unloaded. A segfault occurs when trying to access the plugin or objects created by it after the library providing its functionality has been unloaded.

An exception to this case is plugins defined in libraries (or plugins that link to libraries) that are also linked and used by an active application. For example, the `noether_gui` GUI application links against the same library that provides all of the default plugins. This doesn't cause the same segfault issue described above since this particular library isn't actually unloaded when the plugin goes out of scope because it is required by the concurrently running `noether_gui` app.

This PR fixes the plugin loader widget by keeping loaded plugins in scope (consequently keeping the libraries that provide their functionality loaded) for the lifetime of the plugin loader widget. It also handles the destruction of widgets created by the plugins appropriately to prevent segfaults when the plugin loader widget itself is destroyed.