### PR TITLE
Add normal estimation mesh modifiers

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(${PROJECT_NAME} SHARED
   src/widgets/mesh_modifiers/plane_projection_modifier_widget.cpp
   src/widgets/mesh_modifiers/euclidean_clustering_modifier_widget.cpp
   src/widgets/mesh_modifiers/normal_estimation_pcl_widget.cpp
+  src/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.cpp
   # Resources
   resources/resource.qrc
 )

--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(${PROJECT_NAME} SHARED
   # Mesh Modifiers
   src/widgets/mesh_modifiers/plane_projection_modifier_widget.cpp
   src/widgets/mesh_modifiers/euclidean_clustering_modifier_widget.cpp
+  src/widgets/mesh_modifiers/normal_estimation_pcl_widget.cpp
   # Resources
   resources/resource.qrc
 )

--- a/noether_gui/include/noether_gui/widgets/mesh_modifiers/normal_estimation_pcl_widget.h
+++ b/noether_gui/include/noether_gui/widgets/mesh_modifiers/normal_estimation_pcl_widget.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <noether_gui/widgets.h>
+#include <noether_tpp/core/mesh_modifier.h>
+
+class QDoubleSpinBox;
+
+namespace Ui
+{
+class Vector3dEditor;
+}
+
+namespace noether
+{
+class NormalEstimationPCLMeshModifierWidget : public MeshModifierWidget
+{
+public:
+  NormalEstimationPCLMeshModifierWidget(QWidget* parent = nullptr);
+
+  MeshModifier::ConstPtr create() const override;
+  void configure(const YAML::Node& config) override;
+  void save(YAML::Node& config) const override;
+
+protected:
+  QDoubleSpinBox* radius_;
+  Ui::Vector3dEditor* view_point_;
+};
+
+}  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.h
+++ b/noether_gui/include/noether_gui/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <noether_gui/widgets.h>
+#include <noether_tpp/core/mesh_modifier.h>
+
+namespace noether
+{
+class NormalsFromMeshFacesMeshModifierWidget : public MeshModifierWidget
+{
+public:
+  using MeshModifierWidget::MeshModifierWidget;
+
+  MeshModifier::ConstPtr create() const override;
+};
+
+}  // namespace noether

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -33,6 +33,7 @@
 #include <noether_gui/widgets/mesh_modifiers/plane_projection_modifier_widget.h>
 #include <noether_gui/widgets/mesh_modifiers/euclidean_clustering_modifier_widget.h>
 #include <noether_gui/widgets/mesh_modifiers/normal_estimation_pcl_widget.h>
+#include <noether_gui/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.h>
 
 #include <QWidget>
 #include <QMessageBox>
@@ -156,6 +157,8 @@ using EuclideanClusteringMeshModifierWidgetPlugin =
     WidgetPluginImpl<EuclideanClusteringMeshModifierWidget, MeshModifierWidget>;
 using NormalEstimationPCLMeshModifierWidgetPlugin =
     WidgetPluginImpl<NormalEstimationPCLMeshModifierWidget, MeshModifierWidget>;
+using NormalsFromMeshFacesMeshModifierWidgetPlugin =
+    WidgetPluginImpl<NormalsFromMeshFacesMeshModifierWidget, MeshModifierWidget>;
 
 }  // namespace noether
 
@@ -193,3 +196,4 @@ EXPORT_TPP_WIDGET_PLUGIN(noether::BoundaryEdgePlannerWidgetPlugin, BoundaryEdgeP
 EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(noether::PlaneProjectionMeshModifierWidgetPlugin, PlaneProjectionModifier)
 EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(noether::EuclideanClusteringMeshModifierWidgetPlugin, EuclideanClusteringModifier)
 EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(noether::NormalEstimationPCLMeshModifierWidgetPlugin, NormalEstimationPCL)
+EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(noether::NormalsFromMeshFacesMeshModifierWidgetPlugin, NormalsFromMeshFaces)

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -32,6 +32,7 @@
 // Mesh Modifiers
 #include <noether_gui/widgets/mesh_modifiers/plane_projection_modifier_widget.h>
 #include <noether_gui/widgets/mesh_modifiers/euclidean_clustering_modifier_widget.h>
+#include <noether_gui/widgets/mesh_modifiers/normal_estimation_pcl_widget.h>
 
 #include <QWidget>
 #include <QMessageBox>
@@ -153,6 +154,8 @@ using BoundaryEdgePlannerWidgetPlugin = WidgetPluginImpl<BoundaryEdgePlannerWidg
 using PlaneProjectionMeshModifierWidgetPlugin = WidgetPluginImpl<PlaneProjectionMeshModifierWidget, MeshModifierWidget>;
 using EuclideanClusteringMeshModifierWidgetPlugin =
     WidgetPluginImpl<EuclideanClusteringMeshModifierWidget, MeshModifierWidget>;
+using NormalEstimationPCLMeshModifierWidgetPlugin =
+    WidgetPluginImpl<NormalEstimationPCLMeshModifierWidget, MeshModifierWidget>;
 
 }  // namespace noether
 
@@ -189,3 +192,4 @@ EXPORT_TPP_WIDGET_PLUGIN(noether::BoundaryEdgePlannerWidgetPlugin, BoundaryEdgeP
 
 EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(noether::PlaneProjectionMeshModifierWidgetPlugin, PlaneProjectionModifier)
 EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(noether::EuclideanClusteringMeshModifierWidgetPlugin, EuclideanClusteringModifier)
+EXPORT_MESH_MODIFIER_WIDGET_PLUGIN(noether::NormalEstimationPCLMeshModifierWidgetPlugin, NormalEstimationPCL)

--- a/noether_gui/src/widgets/mesh_modifiers/normal_estimation_pcl_widget.cpp
+++ b/noether_gui/src/widgets/mesh_modifiers/normal_estimation_pcl_widget.cpp
@@ -1,0 +1,60 @@
+#include <noether_gui/widgets/mesh_modifiers/normal_estimation_pcl_widget.h>
+#include "../ui_vector3d_editor_widget.h"
+#include <noether_gui/utils.h>
+
+#include <noether_tpp/mesh_modifiers/normal_estimation_pcl.h>
+#include <QDoubleSpinBox>
+#include <QFormLayout>
+#include <QVBoxLayout>
+#include <QLabel>
+
+namespace noether
+{
+NormalEstimationPCLMeshModifierWidget::NormalEstimationPCLMeshModifierWidget(QWidget* parent)
+  : MeshModifierWidget(parent), radius_(new QDoubleSpinBox(this)), view_point_(new Ui::Vector3dEditor())
+{
+  auto* layout = new QVBoxLayout(this);
+
+  {
+    auto* form_layout = new QFormLayout(this);
+
+    radius_->setMinimum(0.0);
+    radius_->setValue(0.010);
+    radius_->setSingleStep(0.010);
+    radius_->setDecimals(3);
+
+    form_layout->addRow("Radius (m)", radius_);
+    layout->addLayout(form_layout);
+  }
+
+  // Set up the Vector3d editor
+  auto* widget = new QWidget(this);
+  view_point_->setupUi(widget);
+  layout->addWidget(widget);
+}
+
+MeshModifier::ConstPtr NormalEstimationPCLMeshModifierWidget::create() const
+{
+  return std::make_unique<NormalEstimationPCLMeshModifier>(radius_->value(),
+                                                           view_point_->double_spin_box_x->value(),
+                                                           view_point_->double_spin_box_y->value(),
+                                                           view_point_->double_spin_box_z->value());
+}
+
+void NormalEstimationPCLMeshModifierWidget::configure(const YAML::Node& config)
+{
+  radius_->setValue(getEntry<double>(config, "radius"));
+  view_point_->double_spin_box_x->setValue(getEntry<double>(config, "vx"));
+  view_point_->double_spin_box_y->setValue(getEntry<double>(config, "vy"));
+  view_point_->double_spin_box_z->setValue(getEntry<double>(config, "vz"));
+}
+
+void NormalEstimationPCLMeshModifierWidget::save(YAML::Node& config) const
+{
+  config["radius"] = radius_->value();
+  config["vx"] = view_point_->double_spin_box_x->value();
+  config["vy"] = view_point_->double_spin_box_y->value();
+  config["vz"] = view_point_->double_spin_box_z->value();
+}
+
+}  // namespace noether

--- a/noether_gui/src/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.cpp
+++ b/noether_gui/src/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.cpp
@@ -1,0 +1,12 @@
+#include <noether_gui/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.h>
+
+#include <noether_tpp/mesh_modifiers/normals_from_mesh_faces_modifier.h>
+
+namespace noether
+{
+MeshModifier::ConstPtr NormalsFromMeshFacesMeshModifierWidget::create() const
+{
+  return std::make_unique<NormalsFromMeshFacesMeshModifier>();
+}
+
+}  // namespace noether

--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT_NAME} SHARED
   src/mesh_modifiers/fill_holes_modifier.cpp
   src/mesh_modifiers/windowed_sinc_smoothing.cpp
   src/mesh_modifiers/plane_projection_modifier.cpp
+  src/mesh_modifiers/normal_estimation_pcl.cpp
   # Tool Path Modifiers
   src/tool_path_modifiers/circular_lead_in_modifier.cpp
   src/tool_path_modifiers/circular_lead_out_modifier.cpp

--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(${PROJECT_NAME} SHARED
   src/mesh_modifiers/windowed_sinc_smoothing.cpp
   src/mesh_modifiers/plane_projection_modifier.cpp
   src/mesh_modifiers/normal_estimation_pcl.cpp
+  src/mesh_modifiers/normals_from_mesh_faces_modifier.cpp
   # Tool Path Modifiers
   src/tool_path_modifiers/circular_lead_in_modifier.cpp
   src/tool_path_modifiers/circular_lead_out_modifier.cpp

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/normal_estimation_pcl.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/normal_estimation_pcl.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <noether_tpp/core/mesh_modifier.h>
+
+namespace noether
+{
+class NormalEstimationPCLMeshModifier : public MeshModifier
+{
+public:
+  NormalEstimationPCLMeshModifier(double radius, double vx = 0.0, double vy = 0.0, double vz = 0.0);
+
+  std::vector<pcl::PolygonMesh> modify(const pcl::PolygonMesh& mesh) const override;
+
+protected:
+  double radius_;
+  double vx_;
+  double vy_;
+  double vz_;
+};
+
+}  // namespace noether

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/normals_from_mesh_faces_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/normals_from_mesh_faces_modifier.h
@@ -1,0 +1,13 @@
+#include <noether_tpp/core/mesh_modifier.h>
+
+namespace noether
+{
+class NormalsFromMeshFacesMeshModifier : public MeshModifier
+{
+public:
+  using MeshModifier::MeshModifier;
+
+  std::vector<pcl::PolygonMesh> modify(const pcl::PolygonMesh& mesh) const override;
+};
+
+}  // namespace noether

--- a/noether_tpp/include/noether_tpp/utils.h
+++ b/noether_tpp/include/noether_tpp/utils.h
@@ -1,5 +1,9 @@
 #include <noether_tpp/core/tool_path_modifier.h>
+
 #include <pcl/PCLPointField.h>
+#include <pcl/geometry/mesh_traits.h>
+#include <pcl/geometry/triangle_mesh.h>
+#include <pcl/PolygonMesh.h>
 
 namespace noether
 {
@@ -18,5 +22,17 @@ std::vector<pcl::PCLPointField>::const_iterator findField(const std::vector<pcl:
 
 std::vector<pcl::PCLPointField>::const_iterator findFieldOrThrow(const std::vector<pcl::PCLPointField>& fields,
                                                                  const std::string& name);
+
+Eigen::Vector3f getPoint(const pcl::PCLPointCloud2& cloud, const std::uint32_t pt_idx);
+
+Eigen::Vector3f getNormal(const pcl::PCLPointCloud2& cloud, const std::uint32_t pt_idx);
+
+using MeshTraits = pcl::geometry::DefaultMeshTraits<std::uint32_t>;
+using TriangleMesh = pcl::geometry::TriangleMesh<MeshTraits>;
+
+/**
+ * @brief Creates a triangle mesh representation of the input polygon mesh
+ */
+TriangleMesh createTriangleMesh(const pcl::PolygonMesh& input);
 
 }  // namespace noether

--- a/noether_tpp/include/noether_tpp/utils.h
+++ b/noether_tpp/include/noether_tpp/utils.h
@@ -23,6 +23,8 @@ std::vector<pcl::PCLPointField>::const_iterator findField(const std::vector<pcl:
 std::vector<pcl::PCLPointField>::const_iterator findFieldOrThrow(const std::vector<pcl::PCLPointField>& fields,
                                                                  const std::string& name);
 
+bool hasNormals(const pcl::PolygonMesh& mesh);
+
 Eigen::Vector3f getPoint(const pcl::PCLPointCloud2& cloud, const std::uint32_t pt_idx);
 
 Eigen::Vector3f getNormal(const pcl::PCLPointCloud2& cloud, const std::uint32_t pt_idx);

--- a/noether_tpp/src/mesh_modifiers/normal_estimation_pcl.cpp
+++ b/noether_tpp/src/mesh_modifiers/normal_estimation_pcl.cpp
@@ -1,0 +1,48 @@
+#include <noether_tpp/mesh_modifiers/normal_estimation_pcl.h>
+
+#include <pcl/features/normal_3d.h>
+#include <pcl/conversions.h>
+#include <pcl/common/io.h>
+
+namespace noether
+{
+NormalEstimationPCLMeshModifier::NormalEstimationPCLMeshModifier(double radius, double vx, double vy, double vz)
+  : MeshModifier(), radius_(radius), vx_(vx), vy_(vy), vz_(vz)
+{
+}
+
+std::vector<pcl::PolygonMesh> NormalEstimationPCLMeshModifier::modify(const pcl::PolygonMesh& mesh) const
+{
+  // Convert to point cloud for normal estimation
+  auto cloud = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  pcl::fromPCLPointCloud2(mesh.cloud, *cloud);
+
+  // Create the normal estimator
+  pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> normal_estimator;
+  normal_estimator.setInputCloud(cloud);
+  normal_estimator.setRadiusSearch(radius_);
+  normal_estimator.setViewPoint(vx_, vy_, vz_);
+
+  // Set up the search tree
+  auto tree = pcl::make_shared<pcl::search::KdTree<pcl::PointXYZ>>();
+  normal_estimator.setSearchMethod(tree);
+
+  // Compute normals
+  auto normals_cloud = pcl::make_shared<pcl::PointCloud<pcl::Normal>>();
+  normal_estimator.compute(*normals_cloud);
+
+  // Convert back to a point cloud message
+  pcl::PCLPointCloud2 normals;
+  pcl::toPCLPointCloud2(*normals_cloud, normals);
+
+  // Copy the input
+  pcl::PolygonMesh output = mesh;
+
+  // Concatenate
+  if (!pcl::concatenateFields(mesh.cloud, normals, output.cloud))
+    throw std::runtime_error("Failed to concatenate normals into mesh vertex cloud");
+
+  return { output };
+}
+
+}  // namespace noether

--- a/noether_tpp/src/mesh_modifiers/normals_from_mesh_faces_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/normals_from_mesh_faces_modifier.cpp
@@ -1,0 +1,76 @@
+#include <noether_tpp/mesh_modifiers/normals_from_mesh_faces_modifier.h>
+#include <noether_tpp/utils.h>
+
+#include <pcl/point_types.h>
+#include <pcl/common/io.h>
+#include <pcl/conversions.h>
+
+namespace noether
+{
+Eigen::Vector3f computeFaceNormal(const pcl::PolygonMesh& mesh,
+                                  const TriangleMesh& tri_mesh,
+                                  const TriangleMesh::FaceIndex& face_idx)
+{
+  using VAFC = TriangleMesh::VertexAroundFaceCirculator;
+
+  // Get the vertices of this triangle
+  VAFC v_circ = tri_mesh.getVertexAroundFaceCirculator(face_idx);
+  const Eigen::Vector3f v1 = getPoint(mesh.cloud, v_circ++.getTargetIndex().get());
+  const Eigen::Vector3f v2 = getPoint(mesh.cloud, v_circ++.getTargetIndex().get());
+  const Eigen::Vector3f v3 = getPoint(mesh.cloud, v_circ++.getTargetIndex().get());
+
+  // Get the edges v1 -> v2 and v1 -> v3
+  const Eigen::Vector3f edge_12 = v2 - v1;
+  const Eigen::Vector3f edge_13 = v3 - v1;
+
+  // Compute the face normal as the cross product between edge v1 -> v2 and edge v1 -> v3
+  return edge_12.cross(edge_13).normalized();
+}
+
+std::vector<pcl::PolygonMesh> NormalsFromMeshFacesMeshModifier::modify(const pcl::PolygonMesh& mesh) const
+{
+  // Create a triangle mesh representation of the input mesh
+  TriangleMesh tri_mesh = createTriangleMesh(mesh);
+
+  pcl::PointCloud<pcl::Normal> normals_cloud;
+  normals_cloud.reserve(mesh.cloud.height * mesh.cloud.width);
+
+  // For each vertex, circulate the faces around and average the face normals
+  for (std::size_t i = 0; i < tri_mesh.getVertexDataCloud().size(); ++i)
+  {
+    Eigen::Vector3f avg_face_normal = Eigen::Vector3f::Zero();
+    int n_faces = 0;
+
+    using FAVC = TriangleMesh::FaceAroundVertexCirculator;
+    FAVC circ = tri_mesh.getFaceAroundVertexCirculator(TriangleMesh::VertexIndex(i));
+    FAVC circ_end = circ;
+    do
+    {
+      TriangleMesh::FaceIndex face_idx = circ.getTargetIndex();
+      if (face_idx.isValid())
+      {
+        avg_face_normal += computeFaceNormal(mesh, tri_mesh, face_idx);
+        ++n_faces;
+      }
+    } while (++circ != circ_end);
+
+    pcl::Normal normal;
+    normal.getNormalVector3fMap() = (avg_face_normal / n_faces).normalized();
+    normals_cloud.push_back(normal);
+  }
+
+  // Convert to message type
+  pcl::PCLPointCloud2 normals;
+  pcl::toPCLPointCloud2(normals_cloud, normals);
+
+  // Copy the mesh
+  pcl::PolygonMesh output = mesh;
+
+  // Concatenate the normals with the nominal mesh information
+  if (!pcl::concatenateFields(mesh.cloud, normals, output.cloud))
+    throw std::runtime_error("Failed to concatenate normals into mesh vertex cloud");
+
+  return { output };
+}
+
+}  // namespace noether

--- a/noether_tpp/src/tool_path_planners/raster/plane_slicer_raster_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/plane_slicer_raster_planner.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_planners/raster/plane_slicer_raster_planner.h>
+#include <noether_tpp/utils.h>
 
 #include <algorithm>  // std::find(), std::reverse(), std::unique()
 #include <numeric>    // std::iota()
@@ -447,6 +448,9 @@ void PlaneSlicerRasterPlanner::generateRastersBidirectionally(const bool bidirec
 
 ToolPaths PlaneSlicerRasterPlanner::planImpl(const pcl::PolygonMesh& mesh) const
 {
+  if (!hasNormals(mesh))
+    throw std::runtime_error("Mesh does not have vertex normals");
+
   // Convert input mesh to VTK type & calculate normals if necessary
   vtkSmartPointer<vtkPolyData> mesh_data_ = vtkSmartPointer<vtkPolyData>::New();
   pcl::VTKUtils::mesh2vtk(mesh, mesh_data_);

--- a/noether_tpp/src/tool_path_planners/raster/plane_slicer_raster_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/plane_slicer_raster_planner.cpp
@@ -452,30 +452,6 @@ ToolPaths PlaneSlicerRasterPlanner::planImpl(const pcl::PolygonMesh& mesh) const
   pcl::VTKUtils::mesh2vtk(mesh, mesh_data_);
   mesh_data_->BuildLinks();
   mesh_data_->BuildCells();
-  if (!mesh_data_->GetPointData()->GetNormals() || !mesh_data_->GetCellData()->GetNormals())
-  {
-    vtkSmartPointer<vtkPolyDataNormals> normal_generator = vtkSmartPointer<vtkPolyDataNormals>::New();
-    normal_generator->SetInputData(mesh_data_);
-    normal_generator->ComputePointNormalsOn();
-    normal_generator->SetComputeCellNormals(!mesh_data_->GetCellData()->GetNormals());
-    normal_generator->SetFeatureAngle(M_PI_2);
-    normal_generator->SetSplitting(true);
-    normal_generator->SetConsistency(true);
-    normal_generator->SetAutoOrientNormals(false);
-    normal_generator->SetFlipNormals(false);
-    normal_generator->SetNonManifoldTraversal(false);
-    normal_generator->Update();
-
-    if (!mesh_data_->GetPointData()->GetNormals())
-    {
-      mesh_data_->GetPointData()->SetNormals(normal_generator->GetOutput()->GetPointData()->GetNormals());
-    }
-
-    if (!mesh_data_->GetCellData()->GetNormals())
-    {
-      mesh_data_->GetCellData()->SetNormals(normal_generator->GetOutput()->GetCellData()->GetNormals());
-    }
-  }
 
   // Use principal component analysis (PCA) to determine the principal axes of the mesh
   Eigen::Vector3d mesh_normal;  // Unit vector along shortest mesh PCA direction

--- a/noether_tpp/src/utils.cpp
+++ b/noether_tpp/src/utils.cpp
@@ -60,6 +60,15 @@ std::vector<pcl::PCLPointField>::const_iterator findFieldOrThrow(const std::vect
   return it;
 }
 
+bool hasNormals(const pcl::PolygonMesh& mesh)
+{
+  auto nx_it = noether::findField(mesh.cloud.fields, "normal_x");
+  auto ny_it = noether::findField(mesh.cloud.fields, "normal_y");
+  auto nz_it = noether::findField(mesh.cloud.fields, "normal_z");
+
+  return nx_it != mesh.cloud.fields.end() && ny_it != mesh.cloud.fields.end() && nz_it != mesh.cloud.fields.end();
+}
+
 Eigen::Vector3f getPoint(const pcl::PCLPointCloud2& cloud, const std::uint32_t pt_idx)
 {
   // Find the x, y, and z fields

--- a/noether_tpp/src/utils.cpp
+++ b/noether_tpp/src/utils.cpp
@@ -60,4 +60,86 @@ std::vector<pcl::PCLPointField>::const_iterator findFieldOrThrow(const std::vect
   return it;
 }
 
+Eigen::Vector3f getPoint(const pcl::PCLPointCloud2& cloud, const std::uint32_t pt_idx)
+{
+  // Find the x, y, and z fields
+  auto x_it = noether::findFieldOrThrow(cloud.fields, "x");
+  auto y_it = noether::findFieldOrThrow(cloud.fields, "y");
+  auto z_it = noether::findFieldOrThrow(cloud.fields, "z");
+
+  // Check that the xyz fields are floats and contiguous
+  if ((y_it->offset - x_it->offset != 4) || (z_it->offset - y_it->offset != 4))
+    throw std::runtime_error("XYZ fields are not contiguous floats");
+
+  const std::uint32_t offset = pt_idx * cloud.point_step;
+  const auto* xyz = reinterpret_cast<const float*>(cloud.data.data() + offset + x_it->offset);
+  return Eigen::Map<const Eigen::Vector3f>(xyz);
+}
+
+Eigen::Vector3f getNormal(const pcl::PCLPointCloud2& cloud, const std::uint32_t pt_idx)
+{
+  auto nx_it = noether::findField(cloud.fields, "normal_x");
+  auto ny_it = noether::findField(cloud.fields, "normal_y");
+  auto nz_it = noether::findField(cloud.fields, "normal_z");
+
+  if (nx_it == cloud.fields.end() || ny_it == cloud.fields.end() || nz_it == cloud.fields.end())
+    throw std::runtime_error("Not all normals exist");
+
+  const std::uint32_t offset = pt_idx * cloud.point_step;
+  const auto* nx = reinterpret_cast<const float*>(cloud.data.data() + offset + nx_it->offset);
+  const auto* ny = reinterpret_cast<const float*>(cloud.data.data() + offset + ny_it->offset);
+  const auto* nz = reinterpret_cast<const float*>(cloud.data.data() + offset + nz_it->offset);
+
+  return Eigen::Vector3f(*nx, *ny, *nz);
+}
+
+TriangleMesh createTriangleMesh(const pcl::PolygonMesh& input)
+{
+  TriangleMesh mesh;
+
+  // Add the vertices
+  for (std::uint32_t i = 0; i < input.cloud.width * input.cloud.height; ++i)
+  {
+    mesh.addVertex(i);
+  }
+
+  // Add the faces
+  for (auto poly = input.polygons.begin(); poly != input.polygons.end(); ++poly)
+  {
+    if (poly->vertices.size() < 3)
+      throw std::runtime_error("Polygon has fewer than 3 vertices");
+
+    // Create individual triangles from the polygon (n_vert - 2 total triangles)
+    for (std::size_t tri = 0; tri < poly->vertices.size() - 2; ++tri)
+    {
+      TriangleMesh::VertexIndices triangle;
+      triangle.resize(3);
+
+      // Get the vertices of a triangle with the first point as the common point
+      for (std::uint32_t i = 0; i < 3; ++i)
+      {
+        std::uint32_t v_ind;
+        switch (i)
+        {
+          case 0:
+            v_ind = poly->vertices[0];
+            break;
+          case 1:
+            v_ind = poly->vertices[tri + 1];
+            break;
+          case 2:
+            v_ind = poly->vertices[tri + 2];
+            break;
+        }
+
+        triangle[i] = TriangleMesh::VertexIndex(v_ind);
+      }
+
+      mesh.addFace(triangle);
+    }
+  }
+
+  return mesh;
+}
+
 }  // namespace noether


### PR DESCRIPTION
This PR adds two mesh modifiers that estimate normals for a mesh (one using traditional PCL normal estimation and another that averages face normals for each vertex). After the creation of these modifiers, it is no longer necessary for the plane slice planner to estimate normals within the planner code.