### PR TITLE
Appending .yaml extension to file when saving tpp config

### DIFF
--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -87,6 +87,8 @@ void ConfigurableTPPPipelineWidget::onSaveConfiguration(const bool /*checked*/)
     QString file = QFileDialog::getSaveFileName(this, "Save configuration file", "", "YAML files (*.yaml)");
     if (file.isEmpty())
       return;
+    if (!file.endsWith(".yaml"))
+      file = file.append(".yaml");
 
     YAML::Node config;
     save(config);


### PR DESCRIPTION
When saving a tpp config file, this checks if the file has a .yaml file extension. If it doesn't, ".yaml" is appended to the file name. 

This change allows the QFileDialog to display the save yaml file when loading a tpp configuration. The QFileDialog for loading a tpp config file has the .yaml filter, so files without the .yaml extension would previously not appear in the dialog. 