### PR TITLE
Added feature to save modified mesh

### DIFF
--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -69,6 +69,7 @@ public:
 private:
   void onLoadMesh(const bool /*checked*/);
   void onPlan(const bool /*checked*/);
+  void onSaveModifiedMesh(const bool /*checked*/);
   void onShowOriginalMesh(const bool);
   void onShowModifiedMesh(const bool);
   void onShowUnmodifiedToolPath(const bool);

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -515,13 +515,12 @@ void TPPWidget::onSaveModifiedMesh(const bool /*checked*/)
   }
 
   // Extract the submeshes from the actor that holds the modified meshes
-  vtkProp3DCollection* parts  = mesh_fragment_actor_->GetParts();
+  vtkProp3DCollection* parts = mesh_fragment_actor_->GetParts();
   if (parts->GetNumberOfItems() == 0)
   {
     const QString warning_text = "No modified meshes found. \n"
                                  "Have you planned a tool path?";
-    const int warning_box_val = QMessageBox::warning(this, "Heads up!",
-                                                     warning_text);
+    const int warning_box_val = QMessageBox::warning(this, "Heads up!", warning_text);
     return;
   }
   for (vtkIdType i = 0; i < parts->GetNumberOfItems(); i++)
@@ -541,7 +540,7 @@ void TPPWidget::onSaveModifiedMesh(const bool /*checked*/)
           writer->SetFileName(file_path.toLocal8Bit().data());
           writer->Write();
         }
-        else // File extension is .ply
+        else  // File extension is .ply
         {
           auto writer = vtkSmartPointer<vtkPLYWriter>::New();
           // Write the modified mesh to a file

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -28,8 +28,10 @@
 #include <vtkOpenGLRenderer.h>
 #include <vtkRenderWindow.h>
 #include <vtkPLYReader.h>
+#include <vtkPLYWriter.h>
 #include <vtkProp3DCollection.h>
 #include <vtkSTLReader.h>
+#include <vtkSTLWriter.h>
 #include <vtkInteractorStyleTrackballCamera.h>
 #include <vtkAxes.h>
 #include <vtkTransformFilter.h>

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -28,6 +28,7 @@
 #include <vtkOpenGLRenderer.h>
 #include <vtkRenderWindow.h>
 #include <vtkPLYReader.h>
+#include <vtkProp3DCollection.h>
 #include <vtkSTLReader.h>
 #include <vtkInteractorStyleTrackballCamera.h>
 #include <vtkAxes.h>
@@ -95,7 +96,7 @@ TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
   // Connect signals
   connect(ui_->action_load_mesh, &QAction::triggered, this, &TPPWidget::onLoadMesh);
   connect(ui_->action_execute_pipeline, &QAction::triggered, this, &TPPWidget::onPlan);
-
+  connect(ui_->action_save_modified_mesh, &QAction::triggered, this, &TPPWidget::onSaveModifiedMesh);
   connect(ui_->action_show_unmodified_mesh, &QAction::triggered, this, &TPPWidget::onShowOriginalMesh);
   connect(ui_->action_show_modified_mesh, &QAction::triggered, this, &TPPWidget::onShowModifiedMesh);
   connect(ui_->action_show_unmodified_tool_path, &QAction::triggered, this, &TPPWidget::onShowUnmodifiedToolPath);
@@ -500,6 +501,56 @@ void TPPWidget::onPlan(const bool /*checked*/)
     std::stringstream ss;
     printException(ex, ss);
     QMessageBox::warning(this, "Tool Path Planning Error", QString::fromStdString(ss.str()));
+  }
+}
+
+void TPPWidget::onSaveModifiedMesh(const bool /*checked*/)
+{
+  QString file_path = QFileDialog::getSaveFileName(this, "Save modified mesh file", "", "Mesh files (*.ply *.stl)");
+
+  // Append .ply extenstion if a file does not have an extention specified
+  if (!file_path.endsWith(".ply") && !file_path.endsWith(".stl"))
+  {
+    file_path.append(".ply");
+  }
+
+  // Extract the submeshes from the actor that holds the modified meshes
+  vtkProp3DCollection* parts  = mesh_fragment_actor_->GetParts();
+  if (parts->GetNumberOfItems() == 0)
+  {
+    const QString warning_text = "No modified meshes found. \n"
+                                 "Have you planned a tool path?";
+    const int warning_box_val = QMessageBox::warning(this, "Heads up!",
+                                                     warning_text);
+    return;
+  }
+  for (vtkIdType i = 0; i < parts->GetNumberOfItems(); i++)
+  {
+    auto actor = vtkActor::SafeDownCast(parts->GetItemAsObject(i));
+    if (actor)
+    {
+      auto map = vtkPolyDataMapper::SafeDownCast(actor->GetMapper());
+      if (map)
+      {
+        auto mesh_poly_data = vtkPolyData::SafeDownCast(map->GetInput());
+        if (file_path.endsWith(".stl"))
+        {
+          auto writer = vtkSmartPointer<vtkSTLWriter>::New();
+          // Write the modified mesh to a file
+          writer->SetInputData(mesh_poly_data);
+          writer->SetFileName(file_path.toLocal8Bit().data());
+          writer->Write();
+        }
+        else // File extension is .ply
+        {
+          auto writer = vtkSmartPointer<vtkPLYWriter>::New();
+          // Write the modified mesh to a file
+          writer->SetInputData(mesh_poly_data);
+          writer->SetFileName(file_path.toLocal8Bit().data());
+          writer->Write();
+        }
+      }
+    }
   }
 }
 

--- a/noether_gui/src/widgets/tpp_widget.ui
+++ b/noether_gui/src/widgets/tpp_widget.ui
@@ -323,7 +323,7 @@
     <string>Save modified mesh</string>
    </property>
    <property name="shortcut">
-    <string>Shift+D</string>
+    <string>Ctrl+D</string>
    </property>
   </action>
   <action name="action_execute_pipeline">

--- a/noether_gui/src/widgets/tpp_widget.ui
+++ b/noether_gui/src/widgets/tpp_widget.ui
@@ -173,6 +173,8 @@
    <addaction name="action_load_config"/>
    <addaction name="action_save_config"/>
    <addaction name="separator"/>
+   <addaction name="action_save_modified_mesh"/>
+   <addaction name="separator"/>
    <addaction name="action_execute_pipeline"/>
   </widget>
   <action name="action_load_config">

--- a/noether_gui/src/widgets/tpp_widget.ui
+++ b/noether_gui/src/widgets/tpp_widget.ui
@@ -83,8 +83,11 @@
      <bool>true</bool>
     </property>
     <addaction name="action_load_mesh"/>
+    <addaction name="separator"/>
     <addaction name="action_load_config"/>
     <addaction name="action_save_config"/>
+    <addaction name="separator"/>
+    <addaction name="action_save_modified_mesh"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="tearOffEnabled">
@@ -172,20 +175,6 @@
    <addaction name="separator"/>
    <addaction name="action_execute_pipeline"/>
   </widget>
-  <action name="action_load_mesh">
-   <property name="icon">
-    <iconset theme="document-open"/>
-   </property>
-   <property name="text">
-    <string>Load mesh...</string>
-   </property>
-   <property name="toolTip">
-    <string>Load mesh from file...</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+O</string>
-   </property>
-  </action>
   <action name="action_load_config">
    <property name="icon">
     <iconset theme="document-properties"/>
@@ -265,20 +254,6 @@
     <string>Ctrl+T</string>
    </property>
   </action>
-  <action name="action_execute_pipeline">
-   <property name="icon">
-    <iconset theme="media-playback-start"/>
-   </property>
-   <property name="text">
-    <string>Plan</string>
-   </property>
-   <property name="toolTip">
-    <string>Plan tool path</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+P</string>
-   </property>
-  </action>
   <action name="action_save_config">
    <property name="icon">
     <iconset theme="document-save"/>
@@ -322,6 +297,45 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
+   </property>
+  </action>
+  <action name="action_load_mesh">
+   <property name="icon">
+    <iconset theme="document-open"/>
+   </property>
+   <property name="text">
+    <string>Load mesh...</string>
+   </property>
+   <property name="toolTip">
+    <string>Load mesh from file...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
+  </action>
+  <action name="action_save_modified_mesh">
+   <property name="icon">
+    <iconset theme="applications-accessories"/>
+   </property>
+   <property name="text">
+    <string>Save modified mesh</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+D</string>
+   </property>
+  </action>
+  <action name="action_execute_pipeline">
+   <property name="icon">
+    <iconset theme="media-playback-start"/>
+   </property>
+   <property name="text">
+    <string>Plan</string>
+   </property>
+   <property name="toolTip">
+    <string>Plan tool path</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
    </property>
   </action>
  </widget>

--- a/noether_gui/src/widgets/tpp_widget.ui
+++ b/noether_gui/src/widgets/tpp_widget.ui
@@ -173,9 +173,9 @@
    <addaction name="action_load_config"/>
    <addaction name="action_save_config"/>
    <addaction name="separator"/>
-   <addaction name="action_save_modified_mesh"/>
-   <addaction name="separator"/>
    <addaction name="action_execute_pipeline"/>
+   <addaction name="separator"/>
+   <addaction name="action_save_modified_mesh"/>
   </widget>
   <action name="action_load_config">
    <property name="icon">
@@ -320,7 +320,7 @@
     <iconset theme="applications-accessories"/>
    </property>
    <property name="text">
-    <string>Save modified mesh</string>
+    <string>Save modified mesh(es)...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>


### PR DESCRIPTION
- Outputs .ply and .stl files if user adds those file extensions for the modified mesh. If no file extension is specified when saving, the .ply extension is appended to the file
- Added action to file menu and toolbar
- Warning message box appears if user tries to save an empty modified mesh (occurs when no toolpath is generated beforehand)