### PR TITLE
Using pcl::io instead of pcl::VTKUtils for mesh conversions

### DIFF
--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -37,7 +37,7 @@
 #include <vtkProperty.h>
 #include <vtkColorSeries.h>
 #include <vtkLine.h>
-#include <pcl/surface/vtk_smoothing/vtk_utils.h>
+#include <pcl/io/vtk_lib_io.h>
 
 namespace noether
 {
@@ -362,7 +362,7 @@ vtkSmartPointer<vtkAssembly> createMeshActors(const std::vector<pcl::PolygonMesh
   for (std::size_t i = 0; i < meshes.size(); ++i)
   {
     vtkSmartPointer<vtkPolyData> mesh_poly_data = vtkSmartPointer<vtkPolyData>::New();
-    pcl::VTKUtils::mesh2vtk(meshes[i], mesh_poly_data);
+    pcl::io::mesh2vtk(meshes[i], mesh_poly_data);
 
     auto map = vtkSmartPointer<vtkPolyDataMapper>::New();
     map->SetInputData(mesh_poly_data);

--- a/noether_tpp/src/mesh_modifiers/clean_data_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/clean_data_modifier.cpp
@@ -8,14 +8,14 @@
 #include <noether_tpp/mesh_modifiers/clean_data_modifier.h>
 
 #include <vtkCleanPolyData.h>
-#include <pcl/surface/vtk_smoothing/vtk_utils.h>
+#include <pcl/io/vtk_lib_io.h>
 
 namespace noether
 {
 std::vector<pcl::PolygonMesh> CleanData::modify(const pcl::PolygonMesh& mesh_in) const
 {
   vtkSmartPointer<vtkPolyData> mesh_data = vtkSmartPointer<vtkPolyData>::New();
-  pcl::VTKUtils::mesh2vtk(mesh_in, mesh_data);
+  pcl::io::mesh2vtk(mesh_in, mesh_data);
 
   mesh_data->BuildCells();
   mesh_data->BuildLinks();
@@ -26,7 +26,7 @@ std::vector<pcl::PolygonMesh> CleanData::modify(const pcl::PolygonMesh& mesh_in)
   mesh_data = cleanPolyData->GetOutput();
 
   pcl::PolygonMesh mesh_out;
-  pcl::VTKUtils::vtk2mesh(mesh_data, mesh_out);
+  pcl::io::vtk2mesh(mesh_data, mesh_out);
   return { mesh_out };
 }
 

--- a/noether_tpp/src/mesh_modifiers/fill_holes_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/fill_holes_modifier.cpp
@@ -23,7 +23,7 @@
 
 #include <vtkFillHolesFilter.h>
 #include <vtkPolyDataNormals.h>
-#include <pcl/surface/vtk_smoothing/vtk_utils.h>
+#include <pcl/io/vtk_lib_io.h>
 
 namespace noether
 {
@@ -32,7 +32,7 @@ FillHoles::FillHoles(const double max_hole_size) : max_hole_size_(max_hole_size)
 std::vector<pcl::PolygonMesh> FillHoles::modify(const pcl::PolygonMesh& mesh_in) const
 {
   vtkSmartPointer<vtkPolyData> mesh_data = vtkSmartPointer<vtkPolyData>::New();
-  pcl::VTKUtils::mesh2vtk(mesh_in, mesh_data);
+  pcl::io::mesh2vtk(mesh_in, mesh_data);
 
   vtkSmartPointer<vtkFillHolesFilter> fill_holes_filter = vtkSmartPointer<vtkFillHolesFilter>::New();
   fill_holes_filter->SetInputData(mesh_data);
@@ -46,7 +46,7 @@ std::vector<pcl::PolygonMesh> FillHoles::modify(const pcl::PolygonMesh& mesh_in)
   normals_rectifier->Update();
 
   pcl::PolygonMesh mesh_out;
-  pcl::VTKUtils::vtk2mesh(normals_rectifier->GetOutput(), mesh_out);
+  pcl::io::vtk2mesh(normals_rectifier->GetOutput(), mesh_out);
   return { mesh_out };
 }
 

--- a/noether_tpp/src/mesh_modifiers/windowed_sinc_smoothing.cpp
+++ b/noether_tpp/src/mesh_modifiers/windowed_sinc_smoothing.cpp
@@ -8,14 +8,14 @@
 #include <noether_tpp/mesh_modifiers/windowed_sinc_smoothing_modifier.h>
 
 #include <vtkWindowedSincPolyDataFilter.h>
-#include <pcl/surface/vtk_smoothing/vtk_utils.h>
+#include <pcl/io/vtk_lib_io.h>
 
 namespace noether
 {
 std::vector<pcl::PolygonMesh> WindowedSincSmoothing::modify(const pcl::PolygonMesh& mesh_in) const
 {
   vtkSmartPointer<vtkPolyData> mesh_data = vtkSmartPointer<vtkPolyData>::New();
-  pcl::VTKUtils::mesh2vtk(mesh_in, mesh_data);
+  pcl::io::mesh2vtk(mesh_in, mesh_data);
 
   mesh_data->BuildCells();
   mesh_data->BuildLinks();
@@ -33,7 +33,7 @@ std::vector<pcl::PolygonMesh> WindowedSincSmoothing::modify(const pcl::PolygonMe
   smoother->Update();
 
   pcl::PolygonMesh mesh_out;
-  pcl::VTKUtils::vtk2mesh(smoother->GetOutput(), mesh_out);
+  pcl::io::vtk2mesh(smoother->GetOutput(), mesh_out);
   return { mesh_out };
 }
 

--- a/noether_tpp/src/tool_path_planners/raster/plane_slicer_raster_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/plane_slicer_raster_planner.cpp
@@ -11,7 +11,7 @@
 #include <pcl/common/common.h>  // pcl::getMinMax3d()
 #include <pcl/common/pca.h>     // pcl::PCA
 #include <pcl/conversions.h>    // pcl::fromPCLPointCloud2
-#include <pcl/surface/vtk_smoothing/vtk_utils.h>
+#include <pcl/io/vtk_lib_io.h>
 #include <vtkAppendPolyData.h>
 #include <vtkCellArray.h>
 #include <vtkCellData.h>
@@ -460,7 +460,7 @@ ToolPaths PlaneSlicerRasterPlanner::planImpl(const pcl::PolygonMesh& mesh) const
 
   // Convert input mesh to VTK type & calculate normals if necessary
   vtkSmartPointer<vtkPolyData> mesh_data_ = vtkSmartPointer<vtkPolyData>::New();
-  pcl::VTKUtils::mesh2vtk(mesh, mesh_data_);
+  pcl::io::mesh2vtk(mesh, mesh_data_);
   mesh_data_->BuildLinks();
   mesh_data_->BuildCells();
 


### PR DESCRIPTION
As mentioned in #292, normals from the input mesh are not preserved when a vtkPolyData object is converted it to a PCL PolygonMesh using pcl::VTKUtils. 

According to [this stale PR on pcl](https://github.com/PointCloudLibrary/pcl/issues/2646), the pcl::io::vtk2mesh retains the normals of the vtkPolyData object when converting it to a PCL PolygonMesh.

This PR uses the vtk2mesh function in pcl::io instead of pcl::VTKUtils to preserve the normals information of the input mesh. This eliminates warnings from the planning pipeline notifying the user that the input mesh does not have normals (even if it does). 