### PR TITLE
Added ability to specify default toolpath config filepath

### DIFF
--- a/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
+++ b/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
@@ -21,7 +21,9 @@ class TPPPipelineWidget;
 class ConfigurableTPPPipelineWidget : public QWidget
 {
 public:
-  ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent = nullptr);
+  ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader,
+                                std::string default_configuration_file_directory = "",
+                                QWidget* parent = nullptr);
 
   void setConfigurationFile(const QString& file);
 
@@ -35,6 +37,7 @@ public:
 private:
   Ui::ConfigurableTPPPipeline* ui_;
   TPPPipelineWidget* pipeline_widget_;
+  std::string default_configuration_file_directory_;
 };
 
 }  // namespace noether

--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -12,10 +12,13 @@
 
 namespace noether
 {
-ConfigurableTPPPipelineWidget::ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
+ConfigurableTPPPipelineWidget::ConfigurableTPPPipelineWidget(boost_plugin_loader::PluginLoader loader,
+                                                             std::string default_configuration_file_directory,
+                                                             QWidget* parent)
   : QWidget(parent)
   , ui_(new Ui::ConfigurableTPPPipeline())
   , pipeline_widget_(new TPPPipelineWidget(std::move(loader), this))
+  , default_configuration_file_directory_(default_configuration_file_directory)
 {
   ui_->setupUi(this);
   layout()->addWidget(pipeline_widget_);
@@ -74,7 +77,10 @@ void ConfigurableTPPPipelineWidget::setConfigurationFile(const QString& file)
 
 void ConfigurableTPPPipelineWidget::onLoadConfiguration(const bool /*checked*/)
 {
-  QString file = QFileDialog::getOpenFileName(this, "Load configuration file", "", "YAML files (*.yaml)");
+  QString file = QFileDialog::getOpenFileName(this,
+                                              "Load configuration file",
+                                              QString::fromStdString(default_configuration_file_directory_),
+                                              "YAML files (*.yaml)");
 
   if (!file.isEmpty())
     setConfigurationFile(file);
@@ -84,7 +90,10 @@ void ConfigurableTPPPipelineWidget::onSaveConfiguration(const bool /*checked*/)
 {
   try
   {
-    QString file = QFileDialog::getSaveFileName(this, "Save configuration file", "", "YAML files (*.yaml)");
+    QString file = QFileDialog::getSaveFileName(this,
+                                                "Save configuration file",
+                                                QString::fromStdString(default_configuration_file_directory_),
+                                                "YAML files (*.yaml)");
     if (file.isEmpty())
       return;
     if (!file.endsWith(".yaml"))

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -47,7 +47,7 @@ namespace noether
 TPPWidget::TPPWidget(boost_plugin_loader::PluginLoader loader, QWidget* parent)
   : QMainWindow(parent)
   , ui_(new Ui::TPP())
-  , pipeline_widget_(new ConfigurableTPPPipelineWidget(std::move(loader), this))
+  , pipeline_widget_(new ConfigurableTPPPipelineWidget(std::move(loader), "", this))
   , render_widget_(new RenderWidget(this))
   , renderer_(vtkSmartPointer<vtkOpenGLRenderer>::New())
   , mesh_mapper_(vtkSmartPointer<vtkOpenGLPolyDataMapper>::New())


### PR DESCRIPTION
Per commit title. Exposes default filepaths for QFileDialogs in configurable tpp pipeline widget constructor.