### PR TITLE
GUI Interface Update

### DIFF
--- a/docs/page_getting_started.dox
+++ b/docs/page_getting_started.dox
@@ -8,10 +8,12 @@ build the repository.
 
 Clone the repository into a workspace, download the dependencies, and build the workspace.
 
-    cd <ws>
-    vcs import src < dependencies.repos
-    rosdep install --from-paths src -iry
-    <colcon/catkin> build
+```
+cd <ws>
+vcs import src < dependencies.repos
+rosdep install --from-paths src -iry
+<colcon/catkin> build
+```
 
 @section s_gui GUI
 
@@ -27,6 +29,16 @@ Run the application using the following command:
 If you encounter the error `error while loading shared libraries: libjawt.so: cannot open shared object file: No such
 file or directory`, try manually adding the location of the unlinked Java libraries:
 
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-11-openjdk-amd64/lib:/usr/lib/jvm/java-11-openjdk-amd64/lib/server
+@note
+On Ubuntu 22.04:
+```
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-11-openjdk-amd64/lib:/usr/lib/jvm/java-11-openjdk-amd64/lib/server
+```
+
+@note
+On Ubuntu 24.04:
+```
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-21-openjdk-amd64/lib:/usr/lib/jvm/java-21-openjdk-amd64/lib/server
+```
 
 */

--- a/noether_gui/include/noether_gui/plugin_interface.h
+++ b/noether_gui/include/noether_gui/plugin_interface.h
@@ -20,17 +20,27 @@ namespace noether
 {
 /**
  * @ingroup gui_interfaces_plugins
- * @brief Base class for a plugin that can generate a Qt widget
+ * @brief Base class for a plugin that can generate a `BaseWidget<T>` for configuring a tool path planning component
+ * (e.g., mesh modifier, tool path planner, tool path modifier).
  */
 template <typename T>
 class WidgetPlugin
 {
 public:
-  using WidgetT = T;
+  /**
+   * @brief Typedef for the `BaseWidget<T>` type
+   */
+  typedef T BaseWidgetT;
   using Ptr = std::shared_ptr<WidgetPlugin>;
   virtual ~WidgetPlugin() = default;
 
-  virtual QWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const = 0;
+  /**
+   * @brief Returns a pointer to a configured `BaseWidget<T>`: a widget that can configure a tool path planning
+   * component (e.g., mesh modifier, tool path planner, tool path modifier).
+   * @param parent
+   * @param config YAML configuration node used to set the initial values of the widget
+   */
+  virtual BaseWidgetT* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const = 0;
 
 private:
   friend class boost_plugin_loader::PluginLoader;

--- a/noether_gui/include/noether_gui/widgets.h
+++ b/noether_gui/include/noether_gui/widgets.h
@@ -21,9 +21,20 @@ class BaseWidget : public QWidget
 public:
   BaseWidget(QWidget* parent = nullptr) : QWidget(parent) {}
 
+  /**
+   * @brief Creates a tool path planning component of type `T` (e.g., mesh modifier, tool path planner, tool path
+   * modifier)
+   */
   virtual typename T::ConstPtr create() const = 0;
 
+  /**
+   * @brief Configures the elements of the widget from a YAML node
+   */
   virtual void configure(const YAML::Node&) {}
+
+  /**
+   * @brief Saves the configuration of the widget to a YAML node
+   */
   virtual void save(YAML::Node&) const {}
 };
 

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -49,12 +49,12 @@
 
 namespace noether
 {
-template <typename T, typename BaseT>
-struct WidgetPluginImpl : WidgetPlugin<BaseT>
+template <typename WidgetT, typename BaseWidgetT>
+struct WidgetPluginImpl : WidgetPlugin<BaseWidgetT>
 {
-  QWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
+  BaseWidgetT* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
   {
-    auto widget = new T(parent);
+    auto widget = new WidgetT(parent);
 
     // Attempt to configure the widget
     if (!config.IsNull())
@@ -129,7 +129,7 @@ using UniformSpacingLinearModifierWidgetPlugin =
 // Raster Tool Path Planners
 struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
 {
-  QWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
+  ToolPathPlannerWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
   {
     boost_plugin_loader::PluginLoader loader;
     loader.search_libraries.insert(NOETHER_GUI_PLUGINS);
@@ -148,7 +148,7 @@ struct PlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
 
 struct CrossHatchPlaneSlicerRasterPlannerWidgetPlugin : ToolPathPlannerWidgetPlugin
 {
-  QWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
+  ToolPathPlannerWidget* create(QWidget* parent = nullptr, const YAML::Node& config = {}) const override final
   {
     boost_plugin_loader::PluginLoader loader;
     loader.search_libraries.insert(NOETHER_GUI_PLUGINS);

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -65,14 +65,13 @@ struct WidgetPluginImpl : WidgetPlugin<BaseWidgetT>
 };
 
 // Direction Generators
-using FixedDirectionGeneratorWidgetPlugin =
-    WidgetPluginImpl<FixedDirectionGeneratorWidget, DirectionGeneratorWidgetPlugin>;
+using FixedDirectionGeneratorWidgetPlugin = WidgetPluginImpl<FixedDirectionGeneratorWidget, DirectionGeneratorWidget>;
 
 using PrincipalAxisDirectionGeneratorWidgetPlugin =
-    WidgetPluginImpl<PrincipalAxisDirectionGeneratorWidget, DirectionGeneratorWidgetPlugin>;
+    WidgetPluginImpl<PrincipalAxisDirectionGeneratorWidget, DirectionGeneratorWidget>;
 
 // Origin Generators
-using FixedOriginGeneratorWidgetPlugin = WidgetPluginImpl<FixedOriginGeneratorWidget, OriginGeneratorWidgetPlugin>;
+using FixedOriginGeneratorWidgetPlugin = WidgetPluginImpl<FixedOriginGeneratorWidget, OriginGeneratorWidget>;
 
 using CentroidOriginGeneratorWidgetPlugin = WidgetPluginImpl<CentroidOriginGeneratorWidget, OriginGeneratorWidget>;
 

--- a/noether_gui/src/widgets/plugin_loader_widget.hpp
+++ b/noether_gui/src/widgets/plugin_loader_widget.hpp
@@ -145,7 +145,7 @@ void PluginLoaderWidget<PluginT>::save(YAML::Node& config) const
 {
   for (int i = 0; i < ui_->stacked_widget->count(); ++i)
   {
-    auto widget = dynamic_cast<const typename PluginT::WidgetT*>(ui_->stacked_widget->widget(i));
+    auto widget = dynamic_cast<const typename PluginT::BaseWidgetT*>(ui_->stacked_widget->widget(i));
     if (widget)
     {
       YAML::Node widget_config;


### PR DESCRIPTION
Minor changes to the GUI plugin interface definition to require that the plugin produce a widget that inherits `BaseWidget<T>` rather than a widget that just inherits `QWidget`. The idea is to add clarity to the function of the plugin architecture