### PR TITLE
Angle double spin box

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(${PROJECT_NAME} SHARED
   src/plugin_interface.cpp
   # Widgets
   src/widgets/distance_double_spin_box.cpp
+  src/widgets/angle_double_spin_box.cpp
   src/widgets/plugin_loader_widget.cpp
   src/widgets/tpp_pipeline_widget.cpp
   src/widgets/configurable_tpp_pipeline_widget.cpp

--- a/noether_gui/include/noether_gui/widgets/angle_double_spin_box.h
+++ b/noether_gui/include/noether_gui/widgets/angle_double_spin_box.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QDoubleSpinBox>
+
+namespace noether
+{
+/**
+ * @brief Double spin box widget class that supports angle units
+ * @details Supported units are degrees (deg) and radians (rad)
+ */
+class AngleDoubleSpinBox : public QDoubleSpinBox
+{
+public:
+  AngleDoubleSpinBox(QWidget* parent = nullptr);
+
+  double valueFromText(const QString& text) const override;
+  QString textFromValue(double val) const override;
+  QValidator::State validate(QString& input, int& pos) const override;
+
+protected:
+  mutable std::string unit_ = "deg";
+};
+
+}  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/distance_double_spin_box.h
+++ b/noether_gui/include/noether_gui/widgets/distance_double_spin_box.h
@@ -12,7 +12,7 @@ namespace noether
 class DistanceDoubleSpinBox : public QDoubleSpinBox
 {
 public:
-  using QDoubleSpinBox::QDoubleSpinBox;
+  DistanceDoubleSpinBox(QWidget* parent = nullptr);
 
   double valueFromText(const QString& text) const override;
   QString textFromValue(double val) const override;

--- a/noether_gui/src/widgets/angle_double_spin_box.cpp
+++ b/noether_gui/src/widgets/angle_double_spin_box.cpp
@@ -1,0 +1,80 @@
+#include <noether_gui/widgets/angle_double_spin_box.h>
+
+#include <QTextStream>
+#include <QValidator>
+#include <regex>
+#include <cmath>
+
+/**
+ * @brief Helper function for splitting text into a value and unit
+ */
+static std::tuple<double, std::string> split(const std::string& text)
+{
+  const std::regex re("^([\\d\\.]+)\\s*(\\S*)$");
+  std::smatch matches;
+
+  if (!std::regex_search(text, matches, re))
+    return std::make_tuple(0.0, "");
+
+  return std::make_tuple(std::stod(matches.str(1)), matches.str(2));
+}
+
+namespace noether
+{
+AngleDoubleSpinBox::AngleDoubleSpinBox(QWidget* parent) : QDoubleSpinBox(parent)
+{
+  setRange(-M_PI, M_PI);
+  setSingleStep(1.0 * M_PI / 180.0);
+}
+
+QString AngleDoubleSpinBox::textFromValue(double value_rad) const
+{
+  double value;
+
+  if (unit_ == "rad")
+    value = value_rad;
+  else if (unit_.empty())
+    value = value_rad;
+  else if (unit_ == "deg")
+    value = value_rad * 180.0 / M_PI;
+  else
+    throw std::runtime_error("Invalid internal unit");
+
+  QString text;
+  QTextStream stream(&text);
+  stream.setRealNumberPrecision(decimals());
+  stream << value;
+  if (!unit_.empty())
+    stream << " " << QString::fromStdString(unit_);
+
+  return text;
+}
+
+double AngleDoubleSpinBox::valueFromText(const QString& text) const
+{
+  double value;
+  std::string unit;
+  std::tie(value, unit) = split(text.toStdString());
+
+  // If there is no unit defined, assume the last known unit is still active for the sake of conversion
+  if (unit.empty())
+    unit = unit_;
+
+  // Convert the value to meters for internal storage
+  double value_rad;
+  if (unit == "rad")
+    value_rad = value;
+  else if (unit == "deg")
+    value_rad = value * M_PI / 180.0;
+  else
+    return value;
+
+  // Update the unit
+  unit_ = unit;
+
+  return value_rad;
+}
+
+QValidator::State AngleDoubleSpinBox::validate(QString& input, int& pos) const { return QValidator::Acceptable; }
+
+}  // namespace noether

--- a/noether_gui/src/widgets/distance_double_spin_box.cpp
+++ b/noether_gui/src/widgets/distance_double_spin_box.cpp
@@ -20,6 +20,12 @@ static std::tuple<double, std::string> split(const std::string& text)
 
 namespace noether
 {
+DistanceDoubleSpinBox::DistanceDoubleSpinBox(QWidget* parent) : QDoubleSpinBox(parent)
+{
+  setRange(-100.0, 100.0);
+  setSingleStep(0.010);
+}
+
 QString DistanceDoubleSpinBox::textFromValue(double value_m) const
 {
   double value;

--- a/noether_gui/src/widgets/tool_path_modifiers/biased_tool_drag_orientation_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/biased_tool_drag_orientation_modifier_widget.cpp
@@ -1,4 +1,5 @@
 #include <noether_gui/widgets/tool_path_modifiers/biased_tool_drag_orientation_modifier_widget.h>
+#include <noether_gui/widgets/angle_double_spin_box.h>
 #include <noether_gui/widgets/distance_double_spin_box.h>
 #include <noether_gui/utils.h>
 
@@ -18,12 +19,10 @@ BiasedToolDragOrientationToolPathModifierWidget::BiasedToolDragOrientationToolPa
   auto layout = new QFormLayout(this);
 
   // Angle between the grinder and the media being ground
-  angle_offset_ = new QDoubleSpinBox(this);
+  angle_offset_ = new AngleDoubleSpinBox(this);
   angle_offset_->setMinimum(0.0);
-  angle_offset_->setSingleStep(1.0);
-  angle_offset_->setValue(30.0);
   angle_offset_->setDecimals(3);
-  auto label = new QLabel("Angle offset (deg)", this);
+  auto label = new QLabel("Angle offset", this);
   label->setToolTip("The angle between the grinder and the media being ground");
   layout->addRow(label, angle_offset_);
 

--- a/noether_gui/src/widgets/tool_path_modifiers/circular_lead_in_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/circular_lead_in_modifier_widget.cpp
@@ -1,4 +1,5 @@
 #include <noether_gui/widgets/tool_path_modifiers/circular_lead_in_modifier_widget.h>
+#include <noether_gui/widgets/angle_double_spin_box.h>
 #include <noether_gui/widgets/distance_double_spin_box.h>
 #include <noether_gui/utils.h>
 
@@ -18,10 +19,9 @@ CircularLeadInToolPathModifierWidget::CircularLeadInToolPathModifierWidget(QWidg
 {
   auto layout = new QFormLayout(this);
 
-  arc_angle_ = new QDoubleSpinBox(this);
+  arc_angle_ = new AngleDoubleSpinBox(this);
   arc_angle_->setMinimum(0.0);
-  arc_angle_->setSingleStep(1.0);
-  arc_angle_->setValue(90.0);
+  arc_angle_->setValue(M_PI_2);
   arc_angle_->setDecimals(3);
   auto label = new QLabel("Arc sweep (deg)", this);
   label->setToolTip("How far along the approach trajectory arc the waypoints extend from the first waypoint of the "
@@ -37,6 +37,7 @@ CircularLeadInToolPathModifierWidget::CircularLeadInToolPathModifierWidget(QWidg
   auto label_rad = new QLabel("Arc radius", this);
   label_rad->setToolTip("Distance from the first segment point to the center of the approach trajectory arc");
   layout->addRow(label_rad, arc_radius_);
+
   // Number of points
   n_points_ = new QSpinBox(this);
   n_points_->setMinimum(0.0);

--- a/noether_gui/src/widgets/tool_path_modifiers/circular_lead_out_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/circular_lead_out_modifier_widget.cpp
@@ -1,4 +1,5 @@
 #include <noether_gui/widgets/tool_path_modifiers/circular_lead_out_modifier_widget.h>
+#include <noether_gui/widgets/angle_double_spin_box.h>
 #include <noether_gui/widgets/distance_double_spin_box.h>
 #include <noether_gui/utils.h>
 
@@ -19,12 +20,11 @@ CircularLeadOutToolPathModifierWidget::CircularLeadOutToolPathModifierWidget(QWi
   auto layout = new QFormLayout(this);
 
   // Lead out angle (how steep or shallow the exit of the tool path is)
-  arc_angle_ = new QDoubleSpinBox(this);
+  arc_angle_ = new AngleDoubleSpinBox(this);
   arc_angle_->setMinimum(0.0);
-  arc_angle_->setSingleStep(1.0);
-  arc_angle_->setValue(90.0);
+  arc_angle_->setValue(M_PI_2);
   arc_angle_->setDecimals(3);
-  auto label = new QLabel("Arc sweep (deg)", this);
+  auto label = new QLabel("Arc sweep", this);
   label->setToolTip("How far along the exit trajectory arc the waypoints extend from the last waypoint of the segment");
   layout->addRow(label, arc_angle_);
 

--- a/noether_gui/src/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.cpp
@@ -1,4 +1,5 @@
 #include <noether_gui/widgets/tool_path_modifiers/tool_drag_orientation_modifier_widget.h>
+#include <noether_gui/widgets/angle_double_spin_box.h>
 #include <noether_gui/widgets/distance_double_spin_box.h>
 #include <noether_gui/utils.h>
 
@@ -18,12 +19,10 @@ ToolDragOrientationToolPathModifierWidget::ToolDragOrientationToolPathModifierWi
   auto layout = new QFormLayout(this);
 
   // Angle between the grinder and the media being ground
-  angle_offset_ = new QDoubleSpinBox(this);
+  angle_offset_ = new AngleDoubleSpinBox(this);
   angle_offset_->setMinimum(0.0);
-  angle_offset_->setSingleStep(1.0);
-  angle_offset_->setValue(30.0);
   angle_offset_->setDecimals(3);
-  auto label = new QLabel("Angle offset (deg)", this);
+  auto label = new QLabel("Angle offset", this);
   label->setToolTip("The angle between the grinder and the media being ground");
   layout->addRow(label, angle_offset_);
 

--- a/noether_gui/src/widgets/tool_path_planners/raster/cross_hatch_plane_slicer_raster_planner.cpp
+++ b/noether_gui/src/widgets/tool_path_planners/raster/cross_hatch_plane_slicer_raster_planner.cpp
@@ -1,4 +1,5 @@
 #include <noether_gui/widgets/tool_path_planners/raster/cross_hatch_plane_slicer_raster_planner_widget.h>
+#include <noether_gui/widgets/angle_double_spin_box.h>
 #include "ui_raster_planner_widget.h"
 #include <noether_gui/utils.h>
 
@@ -13,14 +14,13 @@ namespace noether
 CrossHatchPlaneSlicerRasterPlannerWidget::CrossHatchPlaneSlicerRasterPlannerWidget(
     boost_plugin_loader::PluginLoader&& loader,
     QWidget* parent)
-  : PlaneSlicerRasterPlannerWidget(std::move(loader), parent), cross_hatch_angle_(new QDoubleSpinBox(this))
+  : PlaneSlicerRasterPlannerWidget(std::move(loader), parent), cross_hatch_angle_(new AngleDoubleSpinBox(this))
 {
   // Search radius
   cross_hatch_angle_->setMinimum(0.0);
-  cross_hatch_angle_->setSingleStep(1.0);
-  cross_hatch_angle_->setValue(90.0);
+  cross_hatch_angle_->setValue(M_PI_2);
   cross_hatch_angle_->setDecimals(3);
-  ui_->form_layout->addRow(new QLabel("Cross Hatch Angle (deg)", this), cross_hatch_angle_);
+  ui_->form_layout->addRow(new QLabel("Cross Hatch Angle", this), cross_hatch_angle_);
 }
 
 ToolPathPlanner::ConstPtr CrossHatchPlaneSlicerRasterPlannerWidget::create() const

--- a/noether_gui/src/widgets/tool_path_planners/raster/direction_generators/principal_axis_direction_generator_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_planners/raster/direction_generators/principal_axis_direction_generator_widget.cpp
@@ -1,4 +1,5 @@
 #include <noether_gui/widgets/tool_path_planners/raster/direction_generators/principal_axis_direction_generator_widget.h>
+#include <noether_gui/widgets/angle_double_spin_box.h>
 #include <noether_gui/utils.h>
 
 #include <noether_tpp/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.h>
@@ -12,12 +13,11 @@ namespace noether
 PrincipalAxisDirectionGeneratorWidget::PrincipalAxisDirectionGeneratorWidget(QWidget* parent)
   : DirectionGeneratorWidget(parent)
   , layout_(new QFormLayout(this))
-  , label_(new QLabel("Rotation offset (deg)", this))
-  , rotation_offset_(new QDoubleSpinBox(this))
+  , label_(new QLabel("Rotation offset", this))
+  , rotation_offset_(new AngleDoubleSpinBox(this))
 {
   layout_->addRow(label_, rotation_offset_);
-  rotation_offset_->setValue(0.0);
-  rotation_offset_->setRange(-180.0, 180.0);
+  rotation_offset_->setValue(M_PI_2);
   rotation_offset_->setDecimals(3);
 }
 


### PR DESCRIPTION
Similar to #301, this PR adds a double spin box for angle values that supports degrees and radians units (internally storing the radians value)