### PR TITLE
YAML serialization for `noether_tpp`

### DIFF
--- a/noether_tpp/include/noether_tpp/macros.h
+++ b/noether_tpp/include/noether_tpp/macros.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#define FWD_DECLARE_YAML_STRUCTS()                                                                                     \
+  namespace YAML                                                                                                       \
+  {                                                                                                                    \
+  class Node;                                                                                                          \
+                                                                                                                       \
+  template <typename T>                                                                                                \
+  struct convert;                                                                                                      \
+                                                                                                                       \
+  template <typename T, typename S>                                                                                    \
+  struct as_if;                                                                                                        \
+                                                                                                                       \
+  }  // namespace YAML
+
+#define FWD_DECLARE_YAML_CONVERT(TYPE)                                                                                 \
+  namespace YAML                                                                                                       \
+  {                                                                                                                    \
+  class Node;                                                                                                          \
+                                                                                                                       \
+  template <typename T>                                                                                                \
+  struct convert;                                                                                                      \
+                                                                                                                       \
+  template <>                                                                                                          \
+  struct convert<TYPE>                                                                                                 \
+  {                                                                                                                    \
+    using T = TYPE;                                                                                                    \
+    static Node encode(const T& val);                                                                                  \
+    static bool decode(const Node& node, T& val);                                                                      \
+  };                                                                                                                   \
+                                                                                                                       \
+  }  // namespace YAML
+
+#define DECLARE_YAML_FRIEND_CLASSES(TYPE)                                                                              \
+  friend class YAML::convert<TYPE>;                                                                                    \
+  friend class YAML::as_if<TYPE, void>;

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/clean_data_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/clean_data_modifier.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -34,7 +35,10 @@ namespace noether
 class CleanData : public MeshModifier
 {
 public:
+  using MeshModifier::MeshModifier;
   std::vector<pcl::PolygonMesh> modify(const pcl::PolygonMesh& mesh) const override;
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::CleanData)

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/euclidean_clustering_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/euclidean_clustering_modifier.h
@@ -22,6 +22,9 @@
 #pragma once
 
 #include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -40,6 +43,11 @@ protected:
   double tolerance_;
   int min_cluster_size_;
   int max_cluster_size_;
+
+  EuclideanClusteringMeshModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(EuclideanClusteringMeshModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::EuclideanClusteringMeshModifier)

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/fill_holes_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/fill_holes_modifier.h
@@ -21,6 +21,9 @@
 #pragma once
 
 #include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -38,6 +41,11 @@ public:
 
 protected:
   double max_hole_size_;
+
+  FillHoles() = default;
+  DECLARE_YAML_FRIEND_CLASSES(FillHoles)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::FillHoles)

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/normal_estimation_pcl.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/normal_estimation_pcl.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -20,6 +23,11 @@ protected:
   double vx_;
   double vy_;
   double vz_;
+
+  NormalEstimationPCLMeshModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(NormalEstimationPCLMeshModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::NormalEstimationPCLMeshModifier)

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/normals_from_mesh_faces_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/normals_from_mesh_faces_modifier.h
@@ -1,4 +1,7 @@
+#pragma once
+
 #include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -16,3 +19,5 @@ public:
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::NormalsFromMeshFacesMeshModifier)

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/plane_projection_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/plane_projection_modifier.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -19,6 +22,11 @@ protected:
   double distance_threshold_;
   unsigned max_planes_;
   unsigned min_vertices_;
+
+  PlaneProjectionMeshModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(PlaneProjectionMeshModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::PlaneProjectionMeshModifier)

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/windowed_sinc_smoothing_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/windowed_sinc_smoothing_modifier.h
@@ -8,6 +8,9 @@
 #pragma once
 
 #include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -44,6 +47,11 @@ public:
 
 protected:
   Config config_;
+
+  WindowedSincSmoothing() = default;
+  DECLARE_YAML_FRIEND_CLASSES(WindowedSincSmoothing)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::WindowedSincSmoothing)

--- a/noether_tpp/include/noether_tpp/serialization.h
+++ b/noether_tpp/include/noether_tpp/serialization.h
@@ -55,6 +55,30 @@ struct convert<Eigen::Transform<FloatT, 3, Eigen::Isometry>>
   }
 };
 
+// Serialization for Eigen::Vector<FloatT, 3, 1>
+template <typename FloatT>
+struct convert<Eigen::Matrix<FloatT, 3, 1>>
+{
+  using T = Eigen::Matrix<FloatT, 3, 1>;
+
+  static Node encode(const T& val)
+  {
+    YAML::Node node;
+    node["x"] = val.x();
+    node["y"] = val.y();
+    node["z"] = val.z();
+    return node;
+  }
+
+  static bool decode(const Node& node, T& val)
+  {
+    val.x() = getMember<FloatT>(node, "x");
+    val.y() = getMember<FloatT>(node, "y");
+    val.z() = getMember<FloatT>(node, "z");
+    return true;
+  }
+};
+
 // Serialization for std::vectors with Eigen-specific allocators (e.g., ToolPath objects)
 template <typename T>
 struct convert<std::vector<T, Eigen::aligned_allocator<T>>>

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/biased_tool_drag_orientation_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/biased_tool_drag_orientation_modifier.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -16,8 +19,13 @@ public:
   ToolPaths modify(ToolPaths tool_paths) const override final;
 
 protected:
-  const double angle_offset_;
-  const double tool_radius_;
+  double angle_offset_;
+  double tool_radius_;
+
+  BiasedToolDragOrientationToolPathModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(BiasedToolDragOrientationToolPathModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::BiasedToolDragOrientationToolPathModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/circular_lead_in_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/circular_lead_in_modifier.h
@@ -1,6 +1,9 @@
 ﻿#pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -15,9 +18,14 @@ public:
   ToolPaths modify(ToolPaths tool_paths) const override final;
 
 protected:
-  const double arc_angle_;
-  const double arc_radius_;
-  const double n_points_;
+  double arc_angle_;
+  double arc_radius_;
+  double n_points_;
+
+  CircularLeadInModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(CircularLeadInModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::CircularLeadInModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/circular_lead_out_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/circular_lead_out_modifier.h
@@ -1,6 +1,9 @@
 ﻿#pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -15,9 +18,14 @@ public:
   ToolPaths modify(ToolPaths tool_paths) const override final;
 
 protected:
-  const double arc_angle_;
-  const double arc_radius_;
-  const double n_points_;
+  double arc_angle_;
+  double arc_radius_;
+  double n_points_;
+
+  CircularLeadOutModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(CircularLeadOutModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::CircularLeadOutModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/concatenate_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/concatenate_modifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -19,3 +20,5 @@ struct ConcatenateModifier : OneTimeToolPathModifier
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::ConcatenateModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/direction_of_travel_orientation_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/direction_of_travel_orientation_modifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -14,3 +15,5 @@ struct DirectionOfTravelOrientationModifier : public OneTimeToolPathModifier
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::DirectionOfTravelOrientationModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/fixed_orientation_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/fixed_orientation_modifier.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -21,7 +24,12 @@ public:
 
 protected:
   /** @brief Reference x-axis direction */
-  const Eigen::Vector3d ref_x_dir_;
+  Eigen::Vector3d ref_x_dir_;
+
+  FixedOrientationModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(FixedOrientationModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::FixedOrientationModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_approach_modifier.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -27,7 +30,12 @@ public:
 
 protected:
   Eigen::Vector3d offset_;
-  const size_t n_points_;
+  size_t n_points_;
+
+  LinearApproachModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(LinearApproachModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::LinearApproachModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_departure_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/linear_departure_modifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <noether_tpp/tool_path_modifiers/linear_approach_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -14,6 +15,11 @@ public:
   using LinearApproachModifier::LinearApproachModifier;
 
   ToolPaths modify(ToolPaths tool_paths) const override final;
+
+protected:
+  DECLARE_YAML_FRIEND_CLASSES(LinearDepartureModifier);
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::LinearDepartureModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/moving_average_orientation_smoothing_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/moving_average_orientation_smoothing_modifier.h
@@ -2,6 +2,10 @@
 
 #include <noether_tpp/core/tool_path_modifier.h>
 
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
+
 namespace noether
 {
 /**
@@ -17,7 +21,12 @@ public:
 
 protected:
   /** @brief Moving average window size **/
-  const std::size_t window_size_;
+  std::size_t window_size_;
+
+  MovingAverageOrientationSmoothingModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(MovingAverageOrientationSmoothingModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::MovingAverageOrientationSmoothingModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/offset_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/offset_modifier.h
@@ -3,6 +3,10 @@
 #include <noether_tpp/core/tool_path_modifier.h>
 #include <Eigen/Geometry>
 
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
+
 namespace noether
 {
 /**
@@ -18,7 +22,12 @@ public:
 
 protected:
   /** @brief fixed tool path offset */
-  const Eigen::Isometry3d offset_;
+  Eigen::Isometry3d offset_;
+
+  OffsetModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(OffsetModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::OffsetModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/raster_organization_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/raster_organization_modifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -19,3 +20,5 @@ struct RasterOrganizationModifier : ToolPathModifier
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::RasterOrganizationModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/snake_organization_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/snake_organization_modifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -19,3 +20,5 @@ struct SnakeOrganizationModifier : ToolPathModifier
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::SnakeOrganizationModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/standard_edge_paths_organization_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/standard_edge_paths_organization_modifier.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -19,8 +22,12 @@ public:
 
   ToolPaths modify(ToolPaths) const override;
 
-private:
-  const Eigen::Vector3d start_reference_;
+protected:
+  Eigen::Vector3d start_reference_;
+
+  DECLARE_YAML_FRIEND_CLASSES(StandardEdgePathsOrganizationModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::StandardEdgePathsOrganizationModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/tool_drag_orientation_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/tool_drag_orientation_modifier.h
@@ -1,6 +1,9 @@
 ﻿#pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -16,8 +19,13 @@ public:
   ToolPaths modify(ToolPaths tool_paths) const override final;
 
 protected:
-  const double angle_offset_;
-  const double tool_radius_;
+  double angle_offset_;
+  double tool_radius_;
+
+  ToolDragOrientationToolPathModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(ToolDragOrientationToolPathModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::ToolDragOrientationToolPathModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/uniform_orientation_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/uniform_orientation_modifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -17,3 +18,5 @@ struct UniformOrientationModifier : public OneTimeToolPathModifier
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::UniformOrientationModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/uniform_spacing_linear_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/uniform_spacing_linear_modifier.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -17,6 +20,11 @@ public:
 
 protected:
   double point_spacing_;
+
+  UniformSpacingLinearModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(UniformSpacingLinearModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::UniformSpacingLinearModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_modifiers/uniform_spacing_spline_modifier.h
+++ b/noether_tpp/include/noether_tpp/tool_path_modifiers/uniform_spacing_spline_modifier.h
@@ -1,4 +1,9 @@
+#pragma once
+
 #include <noether_tpp/core/tool_path_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -15,6 +20,11 @@ public:
 
 protected:
   double point_spacing_;
+
+  UniformSpacingSplineModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(UniformSpacingSplineModifier)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::UniformSpacingSplineModifier)

--- a/noether_tpp/include/noether_tpp/tool_path_planners/edge/boundary_edge_planner.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/edge/boundary_edge_planner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <noether_tpp/tool_path_planners/edge/edge_planner.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -23,3 +24,5 @@ struct BoundaryEdgePlannerFactory : public EdgePlannerFactory
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::BoundaryEdgePlanner)

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/direction_generators/fixed_direction_generator.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/direction_generators/fixed_direction_generator.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/tool_path_planners/raster/raster_planner.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -14,8 +17,13 @@ public:
   FixedDirectionGenerator(const Eigen::Vector3d& direction);
   Eigen::Vector3d generate(const pcl::PolygonMesh& mesh) const override final;
 
-private:
-  const Eigen::Vector3d direction_;
+protected:
+  Eigen::Vector3d direction_;
+
+  FixedDirectionGenerator() = default;
+  DECLARE_YAML_FRIEND_CLASSES(FixedDirectionGenerator)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::FixedDirectionGenerator)

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <noether_tpp/tool_path_planners/raster/raster_planner.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -14,11 +17,15 @@ public:
   PrincipalAxisDirectionGenerator(double rotation_offset = 0.0);
   Eigen::Vector3d generate(const pcl::PolygonMesh& mesh) const override final;
 
-private:
+protected:
   /**
    * @brief Rotation offset (radians) to apply about the smallest principal axis to the generated raster direction
    */
-  const double rotation_offset_;
+  double rotation_offset_;
+
+  DECLARE_YAML_FRIEND_CLASSES(PrincipalAxisDirectionGenerator)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::PrincipalAxisDirectionGenerator)

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/origin_generators/aabb_origin_generator.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/origin_generators/aabb_origin_generator.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <memory>
-
 #include <noether_tpp/tool_path_planners/raster/raster_planner.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -16,3 +15,5 @@ struct AABBCenterOriginGenerator : public OriginGenerator
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::AABBCenterOriginGenerator)

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/origin_generators/centroid_origin_generator.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/origin_generators/centroid_origin_generator.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <memory>
-
 #include <noether_tpp/tool_path_planners/raster/raster_planner.h>
+#include <noether_tpp/macros.h>
 
 namespace noether
 {
@@ -16,3 +15,5 @@ struct CentroidOriginGenerator : public OriginGenerator
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::CentroidOriginGenerator)

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/origin_generators/fixed_origin_generator.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/origin_generators/fixed_origin_generator.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <memory>
-
 #include <noether_tpp/tool_path_planners/raster/raster_planner.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
 
 namespace noether
 {
@@ -17,8 +18,12 @@ public:
   FixedOriginGenerator(const Eigen::Vector3d& origin = Eigen::Vector3d::Zero());
   Eigen::Vector3d generate(const pcl::PolygonMesh& mesh) const override final;
 
-private:
-  const Eigen::Vector3d origin_;
+protected:
+  Eigen::Vector3d origin_;
+
+  DECLARE_YAML_FRIEND_CLASSES(FixedOriginGenerator)
 };
 
 }  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::FixedOriginGenerator)

--- a/noether_tpp/src/mesh_modifiers/clean_data_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/clean_data_modifier.cpp
@@ -9,6 +9,7 @@
 
 #include <vtkCleanPolyData.h>
 #include <pcl/io/vtk_lib_io.h>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
@@ -31,3 +32,11 @@ std::vector<pcl::PolygonMesh> CleanData::modify(const pcl::PolygonMesh& mesh_in)
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::CleanData>::encode(const T& val) { return {}; }
+
+bool convert<noether::CleanData>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/mesh_modifiers/euclidean_clustering_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/euclidean_clustering_modifier.cpp
@@ -20,6 +20,7 @@
  */
 #include <noether_tpp/mesh_modifiers/euclidean_clustering_modifier.h>
 #include <noether_tpp/mesh_modifiers/subset_extraction/subset_extractor.h>
+#include <noether_tpp/serialization.h>
 
 #include <pcl/point_types.h>
 #include <pcl/filters/extract_indices.h>
@@ -62,3 +63,24 @@ std::vector<pcl::PolygonMesh> EuclideanClusteringMeshModifier::modify(const pcl:
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::EuclideanClusteringMeshModifier>::encode(const T& val)
+{
+  Node node;
+  node["tolerance"] = val.tolerance_;
+  node["min_cluster_size"] = val.min_cluster_size_;
+  node["max_cluster_size"] = val.max_cluster_size_;
+  return node;
+}
+
+bool convert<noether::EuclideanClusteringMeshModifier>::decode(const Node& node, T& val)
+{
+  val.tolerance_ = getMember<double>(node, "tolerance");
+  val.min_cluster_size_ = getMember<int>(node, "min_cluster_size");
+  val.max_cluster_size_ = getMember<int>(node, "max_cluster_size");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/mesh_modifiers/fill_holes_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/fill_holes_modifier.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <noether_tpp/mesh_modifiers/fill_holes_modifier.h>
+#include <noether_tpp/serialization.h>
 
 #include <vtkFillHolesFilter.h>
 #include <vtkPolyDataNormals.h>
@@ -51,3 +52,20 @@ std::vector<pcl::PolygonMesh> FillHoles::modify(const pcl::PolygonMesh& mesh_in)
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::FillHoles>::encode(const T& val)
+{
+  Node node;
+  node["max_hole_size"] = val.max_hole_size_;
+  return node;
+}
+
+bool convert<noether::FillHoles>::decode(const Node& node, T& val)
+{
+  val.max_hole_size_ = getMember<double>(node, "max_hole_size");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/mesh_modifiers/normal_estimation_pcl.cpp
+++ b/noether_tpp/src/mesh_modifiers/normal_estimation_pcl.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/mesh_modifiers/normal_estimation_pcl.h>
+#include <noether_tpp/serialization.h>
 
 #include <pcl/features/normal_3d.h>
 #include <pcl/conversions.h>
@@ -46,3 +47,26 @@ std::vector<pcl::PolygonMesh> NormalEstimationPCLMeshModifier::modify(const pcl:
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::NormalEstimationPCLMeshModifier>::encode(const T& val)
+{
+  Node node;
+  node["radius"] = val.radius_;
+  node["vx"] = val.vx_;
+  node["vy"] = val.vy_;
+  node["vz"] = val.vz_;
+  return node;
+}
+
+bool convert<noether::NormalEstimationPCLMeshModifier>::decode(const Node& node, T& val)
+{
+  val.radius_ = getMember<double>(node, "radius");
+  val.vx_ = getMember<double>(node, "vx");
+  val.vy_ = getMember<double>(node, "vy");
+  val.vz_ = getMember<double>(node, "vz");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/mesh_modifiers/normals_from_mesh_faces_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/normals_from_mesh_faces_modifier.cpp
@@ -4,6 +4,7 @@
 #include <pcl/point_types.h>
 #include <pcl/common/io.h>
 #include <pcl/conversions.h>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
@@ -92,3 +93,11 @@ std::vector<pcl::PolygonMesh> NormalsFromMeshFacesMeshModifier::modify(const pcl
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::NormalsFromMeshFacesMeshModifier>::encode(const T& val) { return {}; }
+
+bool convert<noether::NormalsFromMeshFacesMeshModifier>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/mesh_modifiers/plane_projection_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/plane_projection_modifier.cpp
@@ -1,6 +1,7 @@
 #include <noether_tpp/mesh_modifiers/plane_projection_modifier.h>
 #include <noether_tpp/mesh_modifiers/subset_extraction/subset_extractor.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 #include <numeric>
 #include <pcl/sample_consensus/sac_model_plane.h>
@@ -158,3 +159,24 @@ std::vector<pcl::PolygonMesh> PlaneProjectionMeshModifier::modify(const pcl::Pol
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::PlaneProjectionMeshModifier>::encode(const T& val)
+{
+  Node node;
+  node["distance_threshold"] = val.distance_threshold_;
+  node["max_planes"] = val.max_planes_;
+  node["min_vertices"] = val.min_vertices_;
+  return node;
+}
+
+bool convert<noether::PlaneProjectionMeshModifier>::decode(const Node& node, T& val)
+{
+  val.distance_threshold_ = getMember<double>(node, "distance_threshold");
+  val.max_planes_ = getMember<int>(node, "max_planes");
+  val.min_vertices_ = getMember<int>(node, "min_vertices");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/mesh_modifiers/windowed_sinc_smoothing.cpp
+++ b/noether_tpp/src/mesh_modifiers/windowed_sinc_smoothing.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <noether_tpp/mesh_modifiers/windowed_sinc_smoothing_modifier.h>
+#include <noether_tpp/serialization.h>
 
 #include <vtkWindowedSincPolyDataFilter.h>
 #include <pcl/io/vtk_lib_io.h>
@@ -38,3 +39,34 @@ std::vector<pcl::PolygonMesh> WindowedSincSmoothing::modify(const pcl::PolygonMe
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::WindowedSincSmoothing>::encode(const T& val)
+{
+  Node node;
+  node["num_iter"] = val.config_.num_iter;
+  node["enable_boundary_smoothing"] = val.config_.enable_boundary_smoothing;
+  node["enable_feature_edge_smoothing"] = val.config_.enable_feature_edge_smoothing;
+  node["enable_non_manifold_smoothing"] = val.config_.enable_non_manifold_smoothing;
+  node["enable_normalize_coordinates"] = val.config_.enable_normalize_coordinates;
+  node["feature_angle"] = val.config_.feature_angle;
+  node["edge_angle"] = val.config_.edge_angle;
+  node["pass_band"] = val.config_.pass_band;
+  return node;
+}
+
+bool convert<noether::WindowedSincSmoothing>::decode(const Node& node, T& val)
+{
+  val.config_.num_iter = static_cast<std::size_t>(getMember<int>(node, "num_iter"));
+  val.config_.enable_boundary_smoothing = getMember<bool>(node, "enable_boundary_smoothing");
+  val.config_.enable_feature_edge_smoothing = getMember<bool>(node, "enable_feature_edge_smoothing");
+  val.config_.enable_non_manifold_smoothing = getMember<bool>(node, "enable_non_manifold_smoothing");
+  val.config_.enable_normalize_coordinates = getMember<bool>(node, "enable_normalize_coordinates");
+  val.config_.feature_angle = getMember<double>(node, "feature_angle");
+  val.config_.edge_angle = getMember<double>(node, "edge_angle");
+  val.config_.pass_band = getMember<double>(node, "pass_band");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/biased_tool_drag_orientation_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/biased_tool_drag_orientation_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/biased_tool_drag_orientation_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -34,3 +35,22 @@ ToolPaths BiasedToolDragOrientationToolPathModifier::modify(ToolPaths tool_paths
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::BiasedToolDragOrientationToolPathModifier>::encode(const T& val)
+{
+  Node node;
+  node["angle_offset"] = val.angle_offset_;
+  node["tool_radius"] = val.tool_radius_;
+  return node;
+}
+
+bool convert<noether::BiasedToolDragOrientationToolPathModifier>::decode(const Node& node, T& val)
+{
+  val.angle_offset_ = getMember<double>(node, "angle_offset");
+  val.tool_radius_ = getMember<double>(node, "tool_radius");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/circular_lead_in_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/circular_lead_in_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/circular_lead_in_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -42,3 +43,24 @@ ToolPaths CircularLeadInModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::CircularLeadInModifier>::encode(const T& val)
+{
+  Node node;
+  node["arc_angle"] = val.arc_angle_;
+  node["arc_radius"] = val.arc_radius_;
+  node["n_points"] = val.n_points_;
+  return node;
+}
+
+bool convert<noether::CircularLeadInModifier>::decode(const Node& node, T& val)
+{
+  val.arc_angle_ = getMember<double>(node, "arc_angle");
+  val.arc_radius_ = getMember<double>(node, "arc_radius");
+  val.n_points_ = getMember<int>(node, "n_points");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/circular_lead_out_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/circular_lead_out_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/circular_lead_out_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -42,3 +43,24 @@ ToolPaths CircularLeadOutModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::CircularLeadOutModifier>::encode(const T& val)
+{
+  Node node;
+  node["arc_angle"] = val.arc_angle_;
+  node["arc_radius"] = val.arc_radius_;
+  node["n_points"] = val.n_points_;
+  return node;
+}
+
+bool convert<noether::CircularLeadOutModifier>::decode(const Node& node, T& val)
+{
+  val.arc_angle_ = getMember<double>(node, "arc_angle");
+  val.arc_radius_ = getMember<double>(node, "arc_radius");
+  val.n_points_ = getMember<int>(node, "n_points");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/concatenate_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/concatenate_modifier.cpp
@@ -1,8 +1,7 @@
 #include <noether_tpp/tool_path_modifiers/concatenate_modifier.h>
 #include <noether_tpp/tool_path_modifiers/raster_organization_modifier.h>
 #include <noether_tpp/utils.h>
-
-#include <numeric>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -19,3 +18,11 @@ ToolPaths ConcatenateModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::ConcatenateModifier>::encode(const T& val) { return {}; }
+
+bool convert<noether::ConcatenateModifier>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/direction_of_travel_orientation_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/direction_of_travel_orientation_modifier.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_modifiers/direction_of_travel_orientation_modifier.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -47,3 +48,11 @@ ToolPaths DirectionOfTravelOrientationModifier::modify(ToolPaths tool_paths) con
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::DirectionOfTravelOrientationModifier>::encode(const T& val) { return {}; }
+
+bool convert<noether::DirectionOfTravelOrientationModifier>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/fixed_orientation_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/fixed_orientation_modifier.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_modifiers/fixed_orientation_modifier.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -35,3 +36,20 @@ ToolPaths FixedOrientationModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::FixedOrientationModifier>::encode(const T& val)
+{
+  Node node;
+  node["ref_x_dir"] = val.ref_x_dir_;
+  return node;
+}
+
+bool convert<noether::FixedOrientationModifier>::decode(const Node& node, T& val)
+{
+  val.ref_x_dir_ = getMember<Eigen::Vector3d>(node, "ref_x_dir");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/linear_approach_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/linear_approach_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -52,3 +53,22 @@ ToolPaths LinearApproachModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::LinearApproachModifier>::encode(const T& val)
+{
+  Node node;
+  node["offset"] = val.offset_;
+  node["n_points"] = val.n_points_;
+  return node;
+}
+
+bool convert<noether::LinearApproachModifier>::decode(const Node& node, T& val)
+{
+  val.offset_ = getMember<Eigen::Vector3d>(node, "offset");
+  val.n_points_ = getMember<int>(node, "n_points");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/linear_departure_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/linear_departure_modifier.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_modifiers/linear_departure_modifier.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -28,3 +29,17 @@ ToolPaths LinearDepartureModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::LinearDepartureModifier>::encode(const T& val)
+{
+  return convert<noether::LinearApproachModifier>::encode(val);
+}
+
+bool convert<noether::LinearDepartureModifier>::decode(const Node& node, T& val)
+{
+  return convert<noether::LinearApproachModifier>::decode(node, val);
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/moving_average_orientation_smoothing_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/moving_average_orientation_smoothing_modifier.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_modifiers/moving_average_orientation_smoothing_modifier.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -87,3 +88,20 @@ ToolPaths MovingAverageOrientationSmoothingModifier::modify(ToolPaths tool_paths
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::MovingAverageOrientationSmoothingModifier>::encode(const T& val)
+{
+  Node node;
+  node["window_size"] = val.window_size_;
+  return node;
+}
+
+bool convert<noether::MovingAverageOrientationSmoothingModifier>::decode(const Node& node, T& val)
+{
+  val.window_size_ = static_cast<std::size_t>(getMember<double>(node, "window_size"));
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/offset_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/offset_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/offset_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -22,3 +23,20 @@ ToolPaths OffsetModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::OffsetModifier>::encode(const T& val)
+{
+  Node node;
+  node["offset"] = val.offset_;
+  return node;
+}
+
+bool convert<noether::OffsetModifier>::decode(const Node& node, T& val)
+{
+  val.offset_ = getMember<Eigen::Isometry3d>(node, "offset");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/raster_organization_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/raster_organization_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/raster_organization_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 #include <numeric>
 
@@ -49,3 +50,11 @@ ToolPaths RasterOrganizationModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::RasterOrganizationModifier>::encode(const T& val) { return {}; }
+
+bool convert<noether::RasterOrganizationModifier>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/snake_organization_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/snake_organization_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/snake_organization_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 #include <numeric>
 
@@ -25,3 +26,11 @@ ToolPaths SnakeOrganizationModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::SnakeOrganizationModifier>::encode(const T& val) { return {}; }
+
+bool convert<noether::SnakeOrganizationModifier>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/standard_edge_paths_organization_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/standard_edge_paths_organization_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/standard_edge_paths_organization_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 #include <numeric>
 
@@ -156,3 +157,20 @@ ToolPaths StandardEdgePathsOrganizationModifier::modify(ToolPaths tool_paths) co
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::StandardEdgePathsOrganizationModifier>::encode(const T& val)
+{
+  Node node;
+  node["start_reference"] = val.start_reference_;
+  return node;
+}
+
+bool convert<noether::StandardEdgePathsOrganizationModifier>::decode(const Node& node, T& val)
+{
+  val.start_reference_ = getMember<Eigen::Vector3d>(node, "start_reference");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/tool_drag_orientation_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/tool_drag_orientation_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/tool_drag_orientation_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -34,3 +35,22 @@ ToolPaths ToolDragOrientationToolPathModifier::modify(ToolPaths tool_paths) cons
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::ToolDragOrientationToolPathModifier>::encode(const T& val)
+{
+  Node node;
+  node["angle_offset"] = val.angle_offset_;
+  node["tool_radius"] = val.tool_radius_;
+  return node;
+}
+
+bool convert<noether::ToolDragOrientationToolPathModifier>::decode(const Node& node, T& val)
+{
+  val.angle_offset_ = getMember<double>(node, "angle_offset");
+  val.tool_radius_ = getMember<double>(node, "tool_radius");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/uniform_orientation_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/uniform_orientation_modifier.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_modifiers/uniform_orientation_modifier.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -29,3 +30,11 @@ ToolPaths UniformOrientationModifier::modify(ToolPaths tool_paths) const
 };
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::UniformOrientationModifier>::encode(const T& val) { return {}; }
+
+bool convert<noether::UniformOrientationModifier>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/uniform_spacing_linear_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/uniform_spacing_linear_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/uniform_spacing_linear_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 #include <vtkMatrix4x4.h>
 #include <vtkSmartPointer.h>
@@ -86,3 +87,20 @@ ToolPaths UniformSpacingLinearModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::UniformSpacingLinearModifier>::encode(const T& val)
+{
+  Node node;
+  node["point_spacing"] = val.point_spacing_;
+  return node;
+}
+
+bool convert<noether::UniformSpacingLinearModifier>::decode(const Node& node, T& val)
+{
+  val.point_spacing_ = getMember<double>(node, "point_spacing");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_modifiers/uniform_spacing_spline_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/uniform_spacing_spline_modifier.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_modifiers/uniform_spacing_spline_modifier.h>
 #include <noether_tpp/utils.h>
+#include <noether_tpp/serialization.h>
 
 #include <vtkParametricSpline.h>
 #include <vtkPoints.h>
@@ -126,3 +127,20 @@ ToolPaths UniformSpacingSplineModifier::modify(ToolPaths tool_paths) const
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::UniformSpacingSplineModifier>::encode(const T& val)
+{
+  Node node;
+  node["point_spacing"] = val.point_spacing_;
+  return node;
+}
+
+bool convert<noether::UniformSpacingSplineModifier>::decode(const Node& node, T& val)
+{
+  val.point_spacing_ = getMember<double>(node, "point_spacing");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_planners/edge/boundary_edge_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/edge/boundary_edge_planner.cpp
@@ -1,5 +1,6 @@
 #include <noether_tpp/tool_path_planners/edge/boundary_edge_planner.h>
 #include <noether_tpp/utils.h>
+#include <yaml-cpp/yaml.h>
 
 namespace
 {
@@ -123,3 +124,11 @@ ToolPaths BoundaryEdgePlanner::planImpl(const pcl::PolygonMesh& mesh) const
 ToolPathPlanner::ConstPtr BoundaryEdgePlannerFactory::create() const { return std::make_unique<BoundaryEdgePlanner>(); }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::BoundaryEdgePlanner>::encode(const T& val) { return {}; }
+
+bool convert<noether::BoundaryEdgePlanner>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_planners/raster/direction_generators/fixed_direction_generator.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/direction_generators/fixed_direction_generator.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_planners/raster/direction_generators/fixed_direction_generator.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -9,3 +10,20 @@ FixedDirectionGenerator::FixedDirectionGenerator(const Eigen::Vector3d& directio
 Eigen::Vector3d FixedDirectionGenerator::generate(const pcl::PolygonMesh&) const { return direction_; }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::FixedDirectionGenerator>::encode(const T& val)
+{
+  Node node;
+  node["direction"] = val.direction_;
+  return node;
+}
+
+bool convert<noether::FixedDirectionGenerator>::decode(const Node& node, T& val)
+{
+  val.direction_ = getMember<Eigen::Vector3d>(node, "direction");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.h>
+#include <noether_tpp/serialization.h>
 
 #include <boost/make_shared.hpp>
 #include <pcl/common/pca.h>
@@ -25,3 +26,20 @@ Eigen::Vector3d PrincipalAxisDirectionGenerator::generate(const pcl::PolygonMesh
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::PrincipalAxisDirectionGenerator>::encode(const T& val)
+{
+  Node node;
+  node["rotation_offset"] = val.rotation_offset_;
+  return node;
+}
+
+bool convert<noether::PrincipalAxisDirectionGenerator>::decode(const Node& node, T& val)
+{
+  val.rotation_offset_ = getMember<double>(node, "rotation_offset");
+  return true;
+}
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_planners/raster/origin_generators/aabb_origin_generator.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/origin_generators/aabb_origin_generator.cpp
@@ -2,6 +2,7 @@
 
 #include <pcl/common/common.h>
 #include <pcl/conversions.h>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
@@ -16,3 +17,11 @@ Eigen::Vector3d AABBCenterOriginGenerator::generate(const pcl::PolygonMesh& mesh
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::AABBCenterOriginGenerator>::encode(const T& val) { return {}; }
+
+bool convert<noether::AABBCenterOriginGenerator>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_planners/raster/origin_generators/centroid_origin_generator.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/origin_generators/centroid_origin_generator.cpp
@@ -1,6 +1,7 @@
 #include <noether_tpp/tool_path_planners/raster/origin_generators/centroid_origin_generator.h>
 
 #include <pcl/common/centroid.h>
+#include <yaml-cpp/yaml.h>
 
 namespace noether
 {
@@ -16,3 +17,11 @@ Eigen::Vector3d CentroidOriginGenerator::generate(const pcl::PolygonMesh& mesh) 
 }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::CentroidOriginGenerator>::encode(const T& val) { return {}; }
+
+bool convert<noether::CentroidOriginGenerator>::decode(const Node& node, T& val) { return true; }
+
+}  // namespace YAML

--- a/noether_tpp/src/tool_path_planners/raster/origin_generators/fixed_origin_generator.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/origin_generators/fixed_origin_generator.cpp
@@ -1,4 +1,5 @@
 #include <noether_tpp/tool_path_planners/raster/origin_generators/fixed_origin_generator.h>
+#include <noether_tpp/serialization.h>
 
 namespace noether
 {
@@ -7,3 +8,20 @@ FixedOriginGenerator::FixedOriginGenerator(const Eigen::Vector3d& origin) : orig
 Eigen::Vector3d FixedOriginGenerator::generate(const pcl::PolygonMesh& mesh) const { return origin_; }
 
 }  // namespace noether
+
+namespace YAML
+{
+Node convert<noether::FixedOriginGenerator>::encode(const T& val)
+{
+  Node node;
+  node["origin"] = val.origin_;
+  return node;
+}
+
+bool convert<noether::FixedOriginGenerator>::decode(const Node& node, T& val)
+{
+  val.origin_ = getMember<Eigen::Vector3d>(node, "origin");
+  return true;
+}
+
+}  // namespace YAML


### PR DESCRIPTION
This PR adds YAML serialization for most classes in `noether_tpp`. This change supports the development of plugins for the `noether_tpp` components.