### PR TITLE
Update CMakeLists to link against VTK Modules

### DIFF
--- a/docs/page_getting_started.dox
+++ b/docs/page_getting_started.dox
@@ -25,20 +25,4 @@ Run the application using the following command:
 
     ros2 run noether_gui noether_gui_app
 
-@note
-If you encounter the error `error while loading shared libraries: libjawt.so: cannot open shared object file: No such
-file or directory`, try manually adding the location of the unlinked Java libraries:
-
-@note
-On Ubuntu 22.04:
-```
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-11-openjdk-amd64/lib:/usr/lib/jvm/java-11-openjdk-amd64/lib/server
-```
-
-@note
-On Ubuntu 24.04:
-```
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/jvm/java-21-openjdk-amd64/lib:/usr/lib/jvm/java-21-openjdk-amd64/lib/server
-```
-
 */

--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -21,10 +21,20 @@ find_package(
 )
 find_package(yaml-cpp REQUIRED)
 find_package(
-  VTK
-  7.1
-  REQUIRED
-  NO_MODULE
+  VTK 9 REQUIRED
+  COMPONENTS CommonCore
+             CommonDataModel
+             CommonTransforms
+             CommonColor
+             CommonMath
+             CommonComputationalGeometry
+             IOGeometry
+             IOPLY
+             FiltersCore
+             FiltersGeneral
+             RenderingCore
+             RenderingAnnotation
+             RenderingOpenGL2
 )
 
 option(NOETHER_ENABLE_CLANG_TIDY "Enables compilation with clang-tidy" OFF)


### PR DESCRIPTION
This PR updates the CMakeLists.txt of the noether_tpp library to link against VTK modules that are used by noether_tpp and nother_gui instead of linking against all VTK modules to the nother_tpp target. This prevents an incompatibility issue with some of VTK's modules that are not directly used by noether when linking against noether libraries in other packages. 

For example, when trying to link against noether_tpp in a library that leverages SQLite, the VTK::sqlite module may cause compatibility issues when trying to build your custom library. 

This PR also introduces a cmake-format bash script and github workflow to the repo to maintain a CMakeLists format consistent with the format used by other ros-industrial repos like scan_n_plan_workshop.

