### PR TITLE
Drop support for Ubuntu Focal

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [focal, jammy, noble]
+        os: [jammy, noble]
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: Ubuntu [Focal, Jammy, Noble]
+name: Ubuntu [Jammy, Noble]
 
 on:
   push:
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [focal, jammy, noble]
+        distro: [jammy, noble]
     container:
       image: ubuntu:${{ matrix.distro }}
       env:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 Platform             | CI Status
 ---------------------|:---------
-Ubuntu Focal         | [![Build Status](https://github.com/ros-industrial/noether/workflows/Ubuntu/badge.svg)](https://github.com/ros-industrial/noether/actions)
 Ubuntu Jammy         | [![Build Status](https://github.com/ros-industrial/noether/workflows/Ubuntu/badge.svg)](https://github.com/ros-industrial/noether/actions)
+Ubuntu Noble         | [![Build Status](https://github.com/ros-industrial/noether/workflows/Ubuntu/badge.svg)](https://github.com/ros-industrial/noether/actions)
 Lint  (Clang-Format) | [![Build Status](https://github.com/ros-industrial/noether/workflows/Clang-Format/badge.svg)](https://github.com/ros-industrial/ros-industrial/actions)
 
 ## Description


### PR DESCRIPTION
Changes per commit message to drop support for Ubuntu Focal (20.04) because it is now EOL and because there are a number of pending updates to this repository that make support for Ubuntu 20.04 challenging