### PR TITLE
Handle case of widget plugin configuration failure

### DIFF
--- a/noether_gui/include/noether_gui/plugin_interface.h
+++ b/noether_gui/include/noether_gui/plugin_interface.h
@@ -2,9 +2,9 @@
 
 #include <noether_gui/widgets.h>
 
+#include <memory>
 #include <noether_tpp/plugin_interface.h>
 #include <string>
-#include <memory>
 #include <yaml-cpp/yaml.h>
 
 namespace noether
@@ -110,7 +110,18 @@ struct SimpleWidgetPlugin : WidgetPluginT
 
     // Attempt to configure the widget
     if (!config.IsNull())
-      widget->configure(config);
+    {
+      try
+      {
+        widget->configure(config);
+      }
+      catch (const std::exception&)
+      {
+        // Delete the widget to prevent it from showing up in the GUI outside of the appropriate layout
+        widget->deleteLater();
+        throw;
+      }
+    }
 
     return widget;
   }

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -73,7 +73,18 @@ struct Plugin_CrossHatchPlaneSlicerRasterPlannerWidget : WidgetPlugin
 
     // Attempt to configure the widget
     if (!config.IsNull())
-      widget->configure(config);
+    {
+      try
+      {
+        widget->configure(config);
+      }
+      catch (const std::exception&)
+      {
+        // Delete the widget to prevent it from showing up in the GUI outside of the appropriate layout
+        widget->deleteLater();
+        throw;
+      }
+    }
 
     return widget;
   }
@@ -142,7 +153,18 @@ struct Plugin_PlaneSlicerRasterPlannerWidget : WidgetPlugin
 
     // Attempt to configure the widget
     if (!config.IsNull())
-      widget->configure(config);
+    {
+      try
+      {
+        widget->configure(config);
+      }
+      catch (const std::exception&)
+      {
+        // Delete the widget to prevent it from showing up in the GUI outside of the appropriate layout
+        widget->deleteLater();
+        throw;
+      }
+    }
 
     return widget;
   }

--- a/noether_gui/src/widgets/plugin_loader_widget.cpp
+++ b/noether_gui/src/widgets/plugin_loader_widget.cpp
@@ -85,9 +85,9 @@ template <typename PluginT>
 void PluginLoaderWidget<PluginT>::addWidget(const QString& plugin_name, const YAML::Node& config)
 {
   // Update the list widget and stacked widget
+  auto widget = factory_->createWidget<PluginT>(plugin_name.toStdString(), config, this);
   ui_->list_widget->addItem(plugin_name);
-  auto foo = factory_->createWidget<PluginT>(plugin_name.toStdString(), config, this);
-  ui_->stacked_widget->addWidget(foo);
+  ui_->stacked_widget->addWidget(widget);
 
   // Set the current row of the list widget to trigger an update in the stacked widget
   ui_->list_widget->setCurrentRow(ui_->list_widget->count() - 1);


### PR DESCRIPTION
This PR fixes an issue when a widget plugin can not be loaded correctly. Previously, the widget would be created and associated with its parent widget. Then when the configuration step failed, the widget was neither deleted nor added to its intended layout position within the parent widget, resulting in it incorrectly appearing on top of the parent widget.

Now, the widget is scheduled for deletion if the configuration step fails, such that it does not erroneously appear in the GUI.