### PR TITLE
Move printException utility from noether_gui to noether_tpp

### DIFF
--- a/noether_gui/include/noether_gui/utils.h
+++ b/noether_gui/include/noether_gui/utils.h
@@ -47,20 +47,4 @@ inline void overwriteWidget(QLayout* layout, QWidget*& from, QWidget* to)
   from = to;
 }
 
-/**
- * @details Adapted from https://en.cppreference.com/w/cpp/error/throw_with_nested
- */
-inline void printException(const std::exception& e, std::ostream& ss, int level = 0)
-{
-  ss << std::string(level * 4, ' ') << e.what() << '\n';
-  try
-  {
-    std::rethrow_if_nested(e);
-  }
-  catch (const std::exception& nested_exception)
-  {
-    printException(nested_exception, ss, level + 1);
-  }
-}
-
 }  // namespace noether

--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -1,5 +1,5 @@
 #include <noether_gui/widgets/configurable_tpp_pipeline_widget.h>
-#include <noether_gui/utils.h>
+#include <noether_tpp/utils.h>
 
 #include <fstream>
 #include <QFileDialog>

--- a/noether_gui/src/widgets/tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/tpp_pipeline_widget.cpp
@@ -5,6 +5,7 @@
 #include <noether_gui/utils.h>
 
 #include <noether_tpp/serialization.h>
+#include <noether_tpp/utils.h>
 #include <noether_tpp/core/tool_path_planner_pipeline.h>
 #include <QMenu>
 #include <QMessageBox>

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -4,6 +4,7 @@
 #include <noether_gui/widgets/tpp_pipeline_widget.h>
 #include <noether_gui/utils.h>
 #include <noether_tpp/serialization.h>
+#include <noether_tpp/utils.h>
 
 #include <pcl/io/vtk_lib_io.h>
 #include <QColorDialog>

--- a/noether_tpp/include/noether_tpp/utils.h
+++ b/noether_tpp/include/noether_tpp/utils.h
@@ -44,4 +44,10 @@ TriangleMesh createTriangleMesh(const pcl::PolygonMesh& input);
  */
 std::tuple<double, std::vector<double>> computeLength(const ToolPathSegment& segment);
 
+/**
+ * @brief Unrolls an exception and captures content from all nested exceptions
+ * @details Adapted from https://en.cppreference.com/w/cpp/error/throw_with_nested
+ */
+void printException(const std::exception& e, std::ostream& ss, int level = 0);
+
 }  // namespace noether

--- a/noether_tpp/src/utils.cpp
+++ b/noether_tpp/src/utils.cpp
@@ -203,4 +203,17 @@ std::tuple<double, std::vector<double>> computeLength(const ToolPathSegment& seg
   return std::make_tuple(length, dists);
 }
 
+void printException(const std::exception& e, std::ostream& ss, int level)
+{
+  ss << std::string(level * 4, ' ') << e.what() << '\n';
+  try
+  {
+    std::rethrow_if_nested(e);
+  }
+  catch (const std::exception& nested_exception)
+  {
+    printException(nested_exception, ss, level + 1);
+  }
+}
+
 }  // namespace noether


### PR DESCRIPTION
This PR moves the printException utility from `noether_gui` to `noether_tpp` for use by downstream projects that interact with the new `noether_tpp` plugins which can throw nested exceptions