### PR TITLE
Configurable TPP Pipeline Widget Update

### DIFF
--- a/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
+++ b/noether_gui/include/noether_gui/widgets/configurable_tpp_pipeline_widget.h
@@ -7,6 +7,9 @@ namespace noether
 class ConfigurableTPPPipelineWidget : public TPPPipelineWidget
 {
 public:
+  static const QString SETTINGS_KEY_DEFAULT_DIRECTORY;
+  static const QString SETTINGS_KEY_LAST_FILE;
+
   ConfigurableTPPPipelineWidget(std::shared_ptr<const WidgetFactory> loader,
                                 std::string default_configuration_file_directory = "",
                                 QWidget* parent = nullptr);
@@ -14,9 +17,6 @@ public:
   void configure(const QString& file);
   void onLoadConfiguration(const bool /*checked*/);
   void onSaveConfiguration(const bool /*checked*/);
-
-protected:
-  std::string default_configuration_file_directory_;
 };
 
 }  // namespace noether

--- a/noether_gui/src/tpp_app.cpp
+++ b/noether_gui/src/tpp_app.cpp
@@ -28,6 +28,8 @@ int main(int argc, char** argv)
   po::notify(vm);
 
   QApplication app(argc, argv);
+  app.setOrganizationName("noether");
+  app.setApplicationName("noether_gui_app");
 
   signal(SIGINT, handleSignal);
   signal(SIGTERM, handleSignal);

--- a/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
+++ b/noether_gui/src/widgets/configurable_tpp_pipeline_widget.cpp
@@ -4,17 +4,27 @@
 #include <fstream>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QSettings>
 #include <QTextStream>
-#include <QAction>
 #include <yaml-cpp/yaml.h>
 
 namespace noether
 {
+static const QString SETTINGS_SECTION = QString("ConfigurableTPPPipelineWidget");
+const QString ConfigurableTPPPipelineWidget::SETTINGS_KEY_DEFAULT_DIRECTORY = SETTINGS_SECTION + QString("default_"
+                                                                                                         "directory");
+const QString ConfigurableTPPPipelineWidget::SETTINGS_KEY_LAST_FILE = SETTINGS_SECTION + QString("last_file");
+
 ConfigurableTPPPipelineWidget::ConfigurableTPPPipelineWidget(std::shared_ptr<const WidgetFactory> factory,
                                                              std::string default_configuration_file_directory,
                                                              QWidget* parent)
-  : TPPPipelineWidget(factory, parent), default_configuration_file_directory_(default_configuration_file_directory)
+  : TPPPipelineWidget(factory, parent)
 {
+  QSettings settings;
+  // Set the default configuration file directory once in settings
+  settings.setValue(SETTINGS_KEY_DEFAULT_DIRECTORY, QString::fromStdString(default_configuration_file_directory));
+  // Add a placeholder entry for the last opened/saved file
+  settings.setValue(SETTINGS_KEY_LAST_FILE, QString{});
 }
 
 void ConfigurableTPPPipelineWidget::configure(const QString& file)
@@ -30,31 +40,56 @@ void ConfigurableTPPPipelineWidget::configure(const QString& file)
     ss << "Failed to open YAML file at '" << file << "'";
     QMessageBox::warning(this, "Configuration Error", message);
   }
+
+  QSettings settings;
+  settings.setValue(SETTINGS_KEY_LAST_FILE, file);
 }
 
 void ConfigurableTPPPipelineWidget::onLoadConfiguration(const bool /*checked*/)
 {
+  QSettings settings;
+
   QString file = QFileDialog::getOpenFileName(this,
                                               "Load configuration file",
-                                              QString::fromStdString(default_configuration_file_directory_),
+                                              settings.value(SETTINGS_KEY_DEFAULT_DIRECTORY).toString(),
                                               "YAML files (*.yaml)");
 
   if (!file.isEmpty())
+  {
+    // Reset the default directory to an empty string such that subsequent file dialogs start in the directory of the
+    // last opened file
+    settings.setValue(SETTINGS_KEY_DEFAULT_DIRECTORY, QString{});
+
+    // Save the last opened file to settings
+    settings.setValue(SETTINGS_KEY_LAST_FILE, file);
+
     configure(file);
+  }
 }
 
 void ConfigurableTPPPipelineWidget::onSaveConfiguration(const bool /*checked*/)
 {
   try
   {
+    QSettings settings;
+
     QString file = QFileDialog::getSaveFileName(this,
                                                 "Save configuration file",
-                                                QString::fromStdString(default_configuration_file_directory_),
+                                                settings.value(SETTINGS_KEY_DEFAULT_DIRECTORY).toString(),
                                                 "YAML files (*.yaml)");
     if (file.isEmpty())
       return;
+
+    // Make sure the file has the YAML suffix
     if (!file.endsWith(".yaml"))
       file = file.append(".yaml");
+
+    // Reset the default directory to an empty string such that subsequent file dialogs start in the directory of the
+    // last saved file
+    settings.setValue(SETTINGS_KEY_DEFAULT_DIRECTORY, QString{});
+
+    // Save the last saved file to settings
+    settings.setValue(SETTINGS_KEY_LAST_FILE, file);
 
     YAML::Node config;
     save(config);


### PR DESCRIPTION
This PR updates the configurable TPP pipeline editor widget to store the default file dialog location using a `QSettings` object. After this setting is accessed once in the opening or saving of a file, it's value is set to empty such that subsequent calls to file dialogs will open in the last place the user accessed, rather than always in the default directory.

This PR also adds the file name of the last opened/saved file to the `QSettings` object such that other widgets can know what file this widget opened or saved