### PR TITLE
Added ability to generate a plane mesh in the GUI app

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(
   src/widgets/tpp_pipeline_widget.cpp
   src/widgets/configurable_tpp_pipeline_widget.cpp
   src/widgets/tpp_widget.cpp
+  src/widgets/generate_plane_mesh_dialog.cpp
   # Tool Path Planners
   # Raster Planner
   src/widgets/tool_path_planners/raster/raster_planner_widget.cpp

--- a/noether_gui/include/noether_gui/widgets/generate_plane_mesh_dialog.h
+++ b/noether_gui/include/noether_gui/widgets/generate_plane_mesh_dialog.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QDialog>
+
+namespace Ui
+{
+class GeneratePlaneMeshDialog;
+}
+
+namespace noether
+{
+class GeneratePlaneMeshDialog : public QDialog
+{
+public:
+  explicit GeneratePlaneMeshDialog(QWidget* parent = nullptr);
+  ~GeneratePlaneMeshDialog();
+
+  double getPlaneLength() const;
+  double getPlaneWidth() const;
+
+private:
+  Ui::GeneratePlaneMeshDialog* ui_;
+};
+}  // namespace noether

--- a/noether_gui/include/noether_gui/widgets/tpp_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tpp_widget.h
@@ -85,6 +85,7 @@ public:
   void showAxes(const bool);
 
 protected:
+  void onGeneratePlaneMesh();
   void onLoadMesh(const bool /*checked*/);
   void onSaveModifiedMeshes(const bool /*checked*/);
   void onSaveToolPaths(const bool /*checked*/);

--- a/noether_gui/src/widgets/generate_plane_mesh_dialog.cpp
+++ b/noether_gui/src/widgets/generate_plane_mesh_dialog.cpp
@@ -1,0 +1,24 @@
+#include <noether_gui/widgets/generate_plane_mesh_dialog.h>
+#include "ui_generate_plane_mesh_dialog.h"
+
+// QT
+#include <QDoubleSpinBox>
+#include <QDialog>
+#include <QWidget>
+
+namespace noether
+{
+GeneratePlaneMeshDialog::GeneratePlaneMeshDialog(QWidget* parent)
+  : QDialog(parent), ui_(new Ui::GeneratePlaneMeshDialog)
+{
+  ui_->setupUi(this);
+  setWindowTitle("Plane Mesh Dimensions");
+}
+
+GeneratePlaneMeshDialog::~GeneratePlaneMeshDialog() { delete ui_; }
+
+double GeneratePlaneMeshDialog::getPlaneLength() const { return ui_->length_dist_spinbox->value(); }
+
+double GeneratePlaneMeshDialog::getPlaneWidth() const { return ui_->width_dist_spinbox->value(); }
+
+}  // namespace noether

--- a/noether_gui/src/widgets/generate_plane_mesh_dialog.ui
+++ b/noether_gui/src/widgets/generate_plane_mesh_dialog.ui
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GeneratePlaneMeshDialog</class>
+ <widget class="QDialog" name="GeneratePlaneMeshDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>238</width>
+    <height>113</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="length_label">
+     <property name="text">
+      <string>Length</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="width_label">
+     <property name="text">
+      <string>Width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="noether::DistanceDoubleSpinBox" name="length_dist_spinbox">
+     <property name="minimum">
+      <double>0.010000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="noether::DistanceDoubleSpinBox" name="width_dist_spinbox">
+     <property name="minimum">
+      <double>0.010000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>noether::DistanceDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>noether_gui/widgets/distance_double_spin_box.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>GeneratePlaneMeshDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>228</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>94</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>GeneratePlaneMeshDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>228</x>
+     <y>85</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>237</x>
+     <y>94</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/noether_gui/src/widgets/tpp_widget.cpp
+++ b/noether_gui/src/widgets/tpp_widget.cpp
@@ -2,6 +2,7 @@
 #include "ui_tpp_widget.h"
 #include <noether_gui/widgets/configurable_tpp_pipeline_widget.h>
 #include <noether_gui/widgets/tpp_pipeline_widget.h>
+#include <noether_gui/widgets/generate_plane_mesh_dialog.h>
 #include <noether_gui/utils.h>
 #include <noether_tpp/serialization.h>
 #include <noether_tpp/utils.h>
@@ -123,6 +124,7 @@ TPPWidget::TPPWidget(std::shared_ptr<const WidgetFactory> factory, QWidget* pare
   connected_path_actor_->SetVisibility(ui_->action_show_modified_tool_path_lines->isChecked());
 
   // Connect signals
+  connect(ui_->action_gen_plane_mesh, &QAction::triggered, this, &TPPWidget::onGeneratePlaneMesh);
   connect(ui_->action_load_mesh, &QAction::triggered, this, &TPPWidget::onLoadMesh);
   connect(ui_->action_execute_pipeline, &QAction::triggered, [this](const bool) { plan(); });
   connect(ui_->action_save_modified_mesh, &QAction::triggered, this, &TPPWidget::onSaveModifiedMeshes);
@@ -614,6 +616,18 @@ void TPPWidget::onSaveToolPaths(const bool /*checked*/)
     file = file.append(".yaml");
 
   saveToolPaths(file);
+}
+
+void TPPWidget::onGeneratePlaneMesh()
+{
+  GeneratePlaneMeshDialog dialog(this);
+  if (dialog.exec() == QDialog::Accepted)
+  {
+    pcl::PolygonMesh mesh = createPlaneMesh(dialog.getPlaneLength(), dialog.getPlaneWidth());
+    std::string file_path = "/tmp/generated_mesh.ply";
+    pcl::io::savePolygonFile(file_path, mesh);
+    setMeshFile(QString::fromStdString(file_path));
+  }
 }
 
 }  // namespace noether

--- a/noether_gui/src/widgets/tpp_widget.ui
+++ b/noether_gui/src/widgets/tpp_widget.ui
@@ -20,7 +20,7 @@
      <x>0</x>
      <y>0</y>
      <width>417</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -33,6 +33,13 @@
     <property name="toolTipsVisible">
      <bool>true</bool>
     </property>
+    <widget class="QMenu" name="menuGenerate_Mesh">
+     <property name="title">
+      <string>Generate Mesh</string>
+     </property>
+     <addaction name="action_gen_plane_mesh"/>
+    </widget>
+    <addaction name="menuGenerate_Mesh"/>
     <addaction name="action_load_mesh"/>
     <addaction name="separator"/>
     <addaction name="action_load_config"/>
@@ -400,12 +407,26 @@
     <string>Ctrl+S</string>
    </property>
   </action>
+  <action name="action_gen_plane_mesh">
+   <property name="icon">
+    <iconset theme="QIcon::ThemeIcon::DocumentNew"/>
+   </property>
+   <property name="text">
+    <string>Plane mesh</string>
+   </property>
+   <property name="toolTip">
+    <string>Generate a planar mesh</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+G</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
    <class>noether::DistanceDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
-   <header location="global">noether_gui/widgets/distance_double_spin_box.h</header>
+   <header>noether_gui/widgets/distance_double_spin_box.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/noether_tpp/include/noether_tpp/utils.h
+++ b/noether_tpp/include/noether_tpp/utils.h
@@ -1,8 +1,10 @@
 #include <noether_tpp/core/tool_path_modifier.h>
 
+#include <pcl/conversions.h>
 #include <pcl/PCLPointField.h>
 #include <pcl/geometry/mesh_traits.h>
 #include <pcl/geometry/triangle_mesh.h>
+#include <pcl/impl/point_types.hpp>
 #include <pcl/PolygonMesh.h>
 
 namespace noether
@@ -50,4 +52,7 @@ std::tuple<double, std::vector<double>> computeLength(const ToolPathSegment& seg
  */
 void printException(const std::exception& e, std::ostream& ss, int level = 0);
 
+/* @brief Creates a mesh of an xy plane with a specified length and width. The plane normal is the z-axis.
+ */
+pcl::PolygonMesh createPlaneMesh(const float length = 1.0, const float width = 1.0);
 }  // namespace noether

--- a/noether_tpp/src/utils.cpp
+++ b/noether_tpp/src/utils.cpp
@@ -216,4 +216,41 @@ void printException(const std::exception& e, std::ostream& ss, int level)
   }
 }
 
+/* The plane mesh has the following structure. 0-3 represent vertices and A and B represent polygons.
+ *
+ *    0---3
+ *    |A /|
+ *    |/ B|
+ *    1---2
+ *
+ */
+pcl::PolygonMesh createPlaneMesh(const float length, const float width)
+{
+  pcl::PolygonMesh mesh;
+
+  // Fill in the points of the mesh cloud
+  pcl::PointCloud<pcl::PointXYZ> cloud;
+  pcl::PointXYZ p0 = { -length / 2, width / 2, 0 };
+  pcl::PointXYZ p1 = { -length / 2, -width / 2, 0 };
+  pcl::PointXYZ p2 = { length / 2, -width / 2, 0 };
+  pcl::PointXYZ p3 = { length / 2, width / 2, 0 };
+  cloud.points.reserve(4);
+  cloud.points.push_back(p0);
+  cloud.points.push_back(p1);
+  cloud.points.push_back(p2);
+  cloud.points.push_back(p3);
+  pcl::toPCLPointCloud2(cloud, mesh.cloud);
+
+  // Define the polygons of the mesh
+  pcl::Vertices polyA;
+  polyA.vertices = { 0, 1, 3 };
+  pcl::Vertices polyB;
+  polyB.vertices = { 1, 2, 3 };
+
+  mesh.polygons.push_back(polyA);
+  mesh.polygons.push_back(polyB);
+
+  return mesh;
+}
+
 }  // namespace noether


### PR DESCRIPTION
Adds ability to generate a mesh of an xy plane given specified dimensions in the Noether GUI app. Added a QMenu in tpp_widget to organize mesh generation actions linked to mesh primitive generator utility functions for future use. 

A QDialog pops up to accept plane mesh dimensions. Replaces functionality proposed in #213 by leveraging existing tool planners on generated mesh primitives. 

Currently, the shortcut to generate a plane mesh is "Ctrl + G" 