### PR TITLE
Cylinder projection mesh modifier

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -69,11 +69,12 @@ add_library(
   src/widgets/tool_path_modifiers/uniform_spacing_spline_modifier_widget.cpp
   src/widgets/tool_path_modifiers/uniform_spacing_linear_modifier_widget.cpp
   # Mesh Modifiers
-  src/widgets/mesh_modifiers/plane_projection_modifier_widget.cpp
+  src/widgets/mesh_modifiers/cylinder_projection_modifier_widget.cpp
   src/widgets/mesh_modifiers/euclidean_clustering_modifier_widget.cpp
+  src/widgets/mesh_modifiers/fill_holes_modifier_widget.cpp
   src/widgets/mesh_modifiers/normal_estimation_pcl_widget.cpp
   src/widgets/mesh_modifiers/normals_from_mesh_faces_modifier_widget.cpp
-  src/widgets/mesh_modifiers/fill_holes_modifier_widget.cpp
+  src/widgets/mesh_modifiers/plane_projection_modifier_widget.cpp
   # Resources
   resources/resource.qrc
 )

--- a/noether_gui/include/noether_gui/widgets/mesh_modifiers/cylinder_projection_modifier_widget.h
+++ b/noether_gui/include/noether_gui/widgets/mesh_modifiers/cylinder_projection_modifier_widget.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <noether_gui/widgets.h>
+
+namespace Ui
+{
+class CylinderSegmentation;
+class Vector3dEditor;
+}  // namespace Ui
+
+namespace noether
+{
+class CylinderProjectionModifierWidget : public BaseWidget
+{
+public:
+  CylinderProjectionModifierWidget(QWidget* parent = nullptr);
+
+  void configure(const YAML::Node& config) override;
+  void save(YAML::Node& config) const override;
+
+protected:
+  Ui::CylinderSegmentation* ui_;
+  Ui::Vector3dEditor* axis_;
+};
+
+}  // namespace noether

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -32,6 +32,7 @@
 #include <noether_gui/widgets/tool_path_modifiers/uniform_spacing_spline_modifier_widget.h>
 #include <noether_gui/widgets/tool_path_modifiers/uniform_spacing_linear_modifier_widget.h>
 // Mesh Modifiers
+#include <noether_gui/widgets/mesh_modifiers/cylinder_projection_modifier_widget.h>
 #include <noether_gui/widgets/mesh_modifiers/plane_projection_modifier_widget.h>
 #include <noether_gui/widgets/mesh_modifiers/euclidean_clustering_modifier_widget.h>
 #include <noether_gui/widgets/mesh_modifiers/normal_estimation_pcl_widget.h>
@@ -45,6 +46,7 @@
 namespace noether
 {
 // Mesh Modifiers
+EXPORT_SIMPLE_MESH_MODIFIER_WIDGET_PLUGIN(CylinderProjectionModifierWidget, CylinderSegmentation)
 EXPORT_SIMPLE_MESH_MODIFIER_WIDGET_PLUGIN(EuclideanClusteringMeshModifierWidget, EuclideanClustering)
 EXPORT_SIMPLE_MESH_MODIFIER_WIDGET_PLUGIN(FillHolesModifierWidget, FillHoles)
 EXPORT_SIMPLE_MESH_MODIFIER_WIDGET_PLUGIN(NormalEstimationPCLMeshModifierWidget, NormalEstimationPCL)

--- a/noether_gui/src/widgets/mesh_modifiers/cylinder_projection_modifier_widget.cpp
+++ b/noether_gui/src/widgets/mesh_modifiers/cylinder_projection_modifier_widget.cpp
@@ -1,0 +1,60 @@
+#include <noether_gui/widgets/mesh_modifiers/cylinder_projection_modifier_widget.h>
+#include <noether_gui/widgets/angle_double_spin_box.h>
+#include <noether_gui/widgets/distance_double_spin_box.h>
+#include "../ui_vector3d_editor_widget.h"
+#include "ui_cylinder_projection_modifier_widget.h"
+
+#include <noether_tpp/serialization.h>
+
+namespace noether
+{
+CylinderProjectionModifierWidget::CylinderProjectionModifierWidget(QWidget* parent)
+  : ui_(new Ui::CylinderSegmentation()), axis_(new Ui::Vector3dEditor())
+{
+  ui_->setupUi(this);
+
+  // Axis
+  axis_->setupUi(ui_->axis_widget);
+  axis_->group_box->setTitle("Axis");
+  axis_->double_spin_box_z->setValue(1.0);
+}
+
+void CylinderProjectionModifierWidget::configure(const YAML::Node& config)
+{
+  ui_->radius_min->setValue(YAML::getMember<double>(config, "min_radius"));
+  ui_->radius_max->setValue(YAML::getMember<double>(config, "max_radius"));
+  ui_->distance_threshold->setValue(YAML::getMember<double>(config, "distance_threshold"));
+
+  auto axis = YAML::getMember<Eigen::Vector3f>(config, "axis");
+  axis_->double_spin_box_x->setValue(axis.x());
+  axis_->double_spin_box_y->setValue(axis.y());
+  axis_->double_spin_box_z->setValue(axis.z());
+
+  ui_->axis_threshold->setValue(YAML::getMember<double>(config, "axis_threshold"));
+  ui_->normal_distance_weight->setValue(YAML::getMember<double>(config, "normal_distance_weight"));
+  ui_->min_vertices->setValue(YAML::getMember<int>(config, "min_vertices"));
+  ui_->max_cylinders->setValue(YAML::getMember<int>(config, "max_cylinders"));
+  ui_->max_iterations->setValue(YAML::getMember<int>(config, "max_iterations"));
+}
+
+void CylinderProjectionModifierWidget::save(YAML::Node& config) const
+{
+  config["name"] = "CylinderSegmentation";
+  config["min_radius"] = ui_->radius_min->value();
+  config["max_radius"] = ui_->radius_max->value();
+  config["distance_threshold"] = ui_->distance_threshold->value();
+
+  Eigen::Vector3f axis = Eigen::Vector3d{ axis_->double_spin_box_x->value(),
+                                          axis_->double_spin_box_y->value(),
+                                          axis_->double_spin_box_z->value() }
+                             .cast<float>();
+  config["axis"] = axis;
+
+  config["axis_threshold"] = ui_->axis_threshold->value();
+  config["normal_distance_weight"] = ui_->normal_distance_weight->value();
+  config["min_vertices"] = ui_->min_vertices->value();
+  config["max_cylinders"] = ui_->max_cylinders->value();
+  config["max_iterations"] = ui_->max_iterations->value();
+}
+
+}  // namespace noether

--- a/noether_gui/src/widgets/mesh_modifiers/cylinder_projection_modifier_widget.ui
+++ b/noether_gui/src/widgets/mesh_modifiers/cylinder_projection_modifier_widget.ui
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CylinderSegmentation</class>
+ <widget class="QWidget" name="CylinderSegmentation">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>318</width>
+    <height>355</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tab_general">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_radius_min">
+         <property name="text">
+          <string>Radius min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="noether::DistanceDoubleSpinBox" name="radius_min">
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="singleStep">
+          <double>0.010000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.200000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_radius_max">
+         <property name="text">
+          <string>Radius max</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="noether::DistanceDoubleSpinBox" name="radius_max">
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="singleStep">
+          <double>0.010000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.300000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_distance_threshold">
+         <property name="text">
+          <string>Distance threshold</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="noether::DistanceDoubleSpinBox" name="distance_threshold">
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="singleStep">
+          <double>0.010000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.025000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_normal_distance_weight">
+         <property name="text">
+          <string>Normal distance weight</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QDoubleSpinBox" name="normal_distance_weight">
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="maximum">
+          <double>1.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.010000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.015000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_min_vertices">
+         <property name="text">
+          <string>Min vertices</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QSpinBox" name="min_vertices">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>1000000000</number>
+         </property>
+         <property name="value">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_max_cylinders">
+         <property name="text">
+          <string>Max cylinders</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QSpinBox" name="max_cylinders">
+         <property name="minimum">
+          <number>-1</number>
+         </property>
+         <property name="value">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_max_iterations">
+         <property name="text">
+          <string>Max iterations</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QSpinBox" name="max_iterations">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>1000000000</number>
+         </property>
+         <property name="value">
+          <number>100</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_axis">
+      <attribute name="title">
+       <string>Axis</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QFormLayout" name="formLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_axis_threshold">
+           <property name="text">
+            <string>Axis threshold</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="noether::AngleDoubleSpinBox" name="axis_threshold">
+           <property name="decimals">
+            <number>3</number>
+           </property>
+           <property name="maximum">
+            <double>3.140000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.175000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QWidget" name="axis_widget" native="true"/>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>noether::DistanceDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header location="global">noether_gui/widgets/distance_double_spin_box.h</header>
+  </customwidget>
+  <customwidget>
+   <class>noether::AngleDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header location="global">noether_gui/widgets/angle_double_spin_box.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(
   src/mesh_modifiers/subset_extraction/extruded_polygon_subset_extractor.cpp
   src/mesh_modifiers/compound_modifier.cpp
   src/mesh_modifiers/clean_data_modifier.cpp
+  src/mesh_modifiers/cylinder_projection_modifier.cpp
   src/mesh_modifiers/euclidean_clustering_modifier.cpp
   src/mesh_modifiers/fill_holes_modifier.cpp
   src/mesh_modifiers/windowed_sinc_smoothing.cpp

--- a/noether_tpp/include/noether_tpp/mesh_modifiers/cylinder_projection_modifier.h
+++ b/noether_tpp/include/noether_tpp/mesh_modifiers/cylinder_projection_modifier.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <noether_tpp/core/mesh_modifier.h>
+#include <noether_tpp/macros.h>
+
+FWD_DECLARE_YAML_STRUCTS()
+
+namespace noether
+{
+/**
+ * @ingroup mesh_modifiers
+ * @brief Mesh modifier that fits a specifiable number of cylinders to the input mesh and projects the inlier vertices
+ * onto the fitted cylinder models
+ * @details This modifier uses RANSAC to sequentially fit cylinder models to the input mesh.
+ * When a valid cylinder model is identified, the inlier vertices are removed from the input mesh into a new submesh and
+ * then projected onto the fitted cylinder model. New cylinder models are then fitted to the remainder of vertices in
+ * the input mesh until either 1) the maximum number of cylinder models have been fitted 2) too few inliers remain in
+ * the input mesh, or 3) no more valid cylinders can be fit to the input mesh.
+ */
+class CylinderProjectionModifier : public MeshModifier
+{
+public:
+  /**
+   * @brief Constructor
+   * @param min_radius Minimum required cylinder radius (m)
+   * @param max_radius Maximum required cylinder radius (m)
+   * @param distance_threshold Maximum distance (m) a point can be from a model of a cylinder to be considered an inlier
+   * @param axis Predicted cylinder axis
+   * @param axis_threshold Maximum angle (radians) by which the axis of a detected cylinder can differ from the axis of
+   * the defined model cylinder
+   * @param normal_distance_weight Distance weighting amount given to normals (vs point positions) when comparing to the
+   * cylinder model (value from [0, 1])
+   * @param min_vertices Minimum number of vertices that a cluster (identfied as a cylinder) must have
+   * @param max_cylinders Maximum number of cylinders to detect
+   * @param max_iterations Maximum number of RANSAC iterations to perform
+   */
+  CylinderProjectionModifier(float min_radius,
+                             float max_radius,
+                             float distance_threshold,
+                             const Eigen::Vector3f& axis = Eigen::Vector3f::UnitZ(),
+                             float axis_threshold = 10.0 * M_PI / 180.0,
+                             float normal_distance_weight = 0.1,
+                             unsigned min_vertices = 1,
+                             int max_cylinders = -1,
+                             unsigned max_iterations = 100);
+
+  std::vector<pcl::PolygonMesh> modify(const pcl::PolygonMesh& mesh) const override;
+
+protected:
+  CylinderProjectionModifier() = default;
+  DECLARE_YAML_FRIEND_CLASSES(CylinderProjectionModifier)
+
+  float min_radius_;
+  float max_radius_;
+  float distance_threshold_;
+  Eigen::Vector3f axis_;
+  float axis_threshold_;
+  float normal_distance_weight_;
+  unsigned min_vertices_;
+  int max_cylinders_;
+  unsigned max_iterations_;
+};
+
+}  // namespace noether
+
+FWD_DECLARE_YAML_CONVERT(noether::CylinderProjectionModifier)

--- a/noether_tpp/src/mesh_modifiers/cylinder_projection_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/cylinder_projection_modifier.cpp
@@ -1,0 +1,223 @@
+#include <noether_tpp/mesh_modifiers/cylinder_projection_modifier.h>
+#include <noether_tpp/mesh_modifiers/subset_extraction/subset_extractor.h>
+#include <noether_tpp/serialization.h>
+#include <noether_tpp/utils.h>
+
+#include <numeric>
+#include <pcl/sample_consensus/ransac.h>
+#include <pcl/sample_consensus/sac_model_cylinder.h>
+#include <pcl/conversions.h>
+
+namespace noether
+{
+/**
+ * @brief Projects points onto the cylinder model in place
+ * @details pcl::SampleConsensusModelCylinder has a bug in `projectPoints` that was fixed in 1.12.1.
+ * To support back to PCL 1.10 (Ubuntu 20.04), we have implemented the projection function ourselves to include the bug
+ * fix
+ */
+void projectInPlace(pcl::PCLPointCloud2& cloud, const Eigen::VectorXf& model_coefficients)
+{
+  Eigen::Vector4f line_pt(model_coefficients[0], model_coefficients[1], model_coefficients[2], 0.0f);
+  Eigen::Vector4f line_dir(model_coefficients[3], model_coefficients[4], model_coefficients[5], 0.0f);
+  float ptdotdir = line_pt.dot(line_dir);
+  float dirdotdir = 1.0f / line_dir.dot(line_dir);
+
+  // Create a helper function for projecting each point
+  // https://github.com/PointCloudLibrary/pcl/blob/5f608cfb5397fe848c7d61c4ae5f5b1ab760ba80/sample_consensus/include/pcl/sample_consensus/impl/sac_model_cylinder.hpp#L398-L407
+  auto project_point = [&](const Eigen::Vector4f& p) -> Eigen::Vector4f {
+    Eigen::VectorXf pp;
+    float k = (p.dot(line_dir) - ptdotdir) * dirdotdir;
+    // Calculate the projection of the point on the line
+    pp.matrix() = line_pt + k * line_dir;
+
+    Eigen::Vector4f dir = p - pp;
+    dir[3] = 0.0f;
+    dir.normalize();
+
+    // Calculate the projection of the point onto the cylinder
+    pp += dir * model_coefficients[6];
+
+    return pp;
+  };
+
+  // Find the x, y, and z fields
+  auto x_it = findFieldOrThrow(cloud.fields, "x");
+  auto y_it = findFieldOrThrow(cloud.fields, "y");
+  auto z_it = findFieldOrThrow(cloud.fields, "z");
+
+  // Check that the xyz fields are floats and contiguous
+  if ((y_it->offset - x_it->offset != 4) || (z_it->offset - y_it->offset != 4))
+    throw std::runtime_error("XYZ fields are not contiguous floats");
+
+  // auto nx_it = findField(cloud.fields, "normal_x");
+  // auto ny_it = findField(cloud.fields, "normal_y");
+  // auto nz_it = findField(cloud.fields, "normal_z");
+
+  // bool update_normals = nx_it != cloud.fields.end() && ny_it != cloud.fields.end() && nz_it != cloud.fields.end();
+
+  for (std::size_t r = 0; r < cloud.height; ++r)
+  {
+    for (std::size_t c = 0; c < cloud.width; ++c)
+    {
+      auto offset = r * cloud.row_step + c * cloud.point_step;
+      float* xyz = reinterpret_cast<float*>(cloud.data.data() + offset + x_it->offset);
+      Eigen::Map<Eigen::Vector4f> p(xyz);
+
+      // Project the point in place
+      p = project_point(p);
+
+      // TODO: update calculation of normals
+      // if (update_normals)
+      // {
+      //   float* nx = reinterpret_cast<float*>(cloud.data.data() + offset + nx_it->offset);
+      //   float* ny = reinterpret_cast<float*>(cloud.data.data() + offset + ny_it->offset);
+      //   float* nz = reinterpret_cast<float*>(cloud.data.data() + offset + nz_it->offset);
+      // }
+    }
+  }
+}
+
+CylinderProjectionModifier::CylinderProjectionModifier(float min_radius,
+                                                       float max_radius,
+                                                       float distance_threshold,
+                                                       const Eigen::Vector3f& axis,
+                                                       float axis_threshold,
+                                                       float normal_distance_weight,
+                                                       unsigned min_vertices,
+                                                       int max_cylinders,
+                                                       unsigned max_iterations)
+  : MeshModifier()
+  , min_radius_(min_radius)
+  , max_radius_(max_radius)
+  , distance_threshold_(distance_threshold)
+  , axis_(axis)
+  , axis_threshold_(axis_threshold)
+  , normal_distance_weight_(normal_distance_weight)
+  , min_vertices_(min_vertices)
+  , max_cylinders_(max_cylinders)
+  , max_iterations_(max_iterations)
+{
+}
+
+std::vector<pcl::PolygonMesh> CylinderProjectionModifier::modify(const pcl::PolygonMesh& mesh) const
+{
+  // Convert the mesh vertices to a point cloud
+  auto cloud_points = pcl::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  pcl::fromPCLPointCloud2(mesh.cloud, *cloud_points);
+
+  // Convert the mesh vertex normals to a point cloud of normals
+  auto cloud_normals = pcl::make_shared<pcl::PointCloud<pcl::Normal>>();
+  pcl::fromPCLPointCloud2(mesh.cloud, *cloud_normals);
+
+  // Set up the output data structure
+  std::vector<pcl::PolygonMesh> output;
+
+  // Set up the RANSAC cylinder fit model
+  auto model = pcl::make_shared<pcl::SampleConsensusModelCylinder<pcl::PointXYZ, pcl::Normal>>(cloud_points);
+  model->setInputNormals(cloud_normals);
+  model->setNormalDistanceWeight(normal_distance_weight_);
+  model->setRadiusLimits(min_radius_, max_radius_);
+  model->setAxis(axis_);
+  model->setEpsAngle(axis_threshold_);
+
+  auto ransac = pcl::make_shared<pcl::RandomSampleConsensus<pcl::PointXYZ>>(model);
+  ransac->setDistanceThreshold(distance_threshold_);
+  ransac->setMaxIterations(max_iterations_);
+
+  // Create a vector of indices for the remaining indices to which a cylinder model can be fit
+  // To start, all indices are remaining (i.e., [0, 1, 2, ..., cloud->size() - 1])
+  std::vector<int> all_indices(cloud_points->size());
+  std::iota(all_indices.begin(), all_indices.end(), 0);
+  std::vector<int> remaining_indices = all_indices;
+
+  /* Detect as many cylinders as possible while:
+   *   - there are at least enough vertices left to form a new model cluster, and
+   *   - we haven't detected more than the maximum number of cylinders
+   */
+  while (remaining_indices.size() >= min_vertices_ && output.size() < max_cylinders_)
+  {
+    // Fit a cylinder model to the vertices using RANSAC
+    model->setIndices(remaining_indices);
+    if (!ransac->computeModel())
+      break;
+
+    // Refine the fit model
+    if (!ransac->refineModel())
+      break;
+
+    // Extract the inliers and ensure there are enough to form a valid model cluster
+    std::vector<int> inliers;
+    ransac->getInliers(inliers);
+    if (inliers.size() < min_vertices_)
+      break;
+
+    // Extract the inlier submesh
+    pcl::PolygonMesh output_mesh = extractSubMeshFromInlierVertices(mesh, inliers);
+    if (!output_mesh.polygons.empty())
+    {
+      // Project the mesh
+      Eigen::VectorXf coefficients;
+      ransac->getModelCoefficients(coefficients);
+      projectInPlace(output_mesh.cloud, coefficients);
+
+      // Append the extracted and projected mesh to the vector of output meshes
+      output.push_back(output_mesh);
+    }
+
+    // Remove the inlier indices from the list of remaining indices
+    std::size_t num_outliers = remaining_indices.size() - inliers.size();
+    if (num_outliers < min_vertices_)
+      break;
+
+    std::vector<int> outliers;
+    outliers.reserve(num_outliers);
+    std::set_difference(remaining_indices.begin(),
+                        remaining_indices.end(),
+                        inliers.begin(),
+                        inliers.end(),
+                        std::back_inserter(outliers));
+    remaining_indices = outliers;
+  }
+
+  return output;
+}
+
+}  // namespace noether
+
+namespace YAML
+{
+/** @cond */
+Node convert<noether::CylinderProjectionModifier>::encode(const noether::CylinderProjectionModifier& val)
+{
+  Node node;
+  node["min_radius"] = val.min_radius_;
+  node["max_radius"] = val.max_radius_;
+  node["distance_threshold"] = val.distance_threshold_;
+  node["axis"] = val.axis_;
+  node["axis_threshold"] = val.axis_threshold_;
+  node["normal_distance_weight"] = val.normal_distance_weight_;
+  node["min_vertices"] = val.min_vertices_;
+  node["max_cylinders"] = val.max_cylinders_;
+  node["max_iterations"] = val.max_iterations_;
+
+  return node;
+}
+
+bool convert<noether::CylinderProjectionModifier>::decode(const Node& node, noether::CylinderProjectionModifier& val)
+{
+  val.min_radius_ = YAML::getMember<double>(node, "min_radius");
+  val.max_radius_ = YAML::getMember<double>(node, "max_radius");
+  val.distance_threshold_ = YAML::getMember<double>(node, "distance_threshold");
+  val.axis_ = YAML::getMember<Eigen::Vector3f>(node, "axis");
+  val.axis_threshold_ = YAML::getMember<double>(node, "axis_threshold");
+  val.normal_distance_weight_ = YAML::getMember<double>(node, "normal_distance_weight");
+  val.min_vertices_ = YAML::getMember<int>(node, "min_vertices");
+  val.max_cylinders_ = YAML::getMember<int>(node, "max_cylinders");
+  val.max_iterations_ = YAML::getMember<int>(node, "max_iterations");
+
+  return true;
+}
+/** @endcond */
+
+}  // namespace YAML

--- a/noether_tpp/src/plugins.cpp
+++ b/noether_tpp/src/plugins.cpp
@@ -4,6 +4,7 @@
 // Mesh modifiers
 #include <noether_tpp/mesh_modifiers/clean_data_modifier.h>
 #include <noether_tpp/mesh_modifiers/compound_modifier.h>
+#include <noether_tpp/mesh_modifiers/cylinder_projection_modifier.h>
 #include <noether_tpp/mesh_modifiers/euclidean_clustering_modifier.h>
 #include <noether_tpp/mesh_modifiers/fill_holes_modifier.h>
 #include <noether_tpp/mesh_modifiers/normal_estimation_pcl.h>
@@ -49,6 +50,7 @@ namespace noether
 {
 // Mesh Modifiers
 EXPORT_SIMPLE_MESH_MODIFIER_PLUGIN(CleanData, CleanData)
+EXPORT_SIMPLE_MESH_MODIFIER_PLUGIN(CylinderProjectionModifier, CylinderSegmentation)
 EXPORT_SIMPLE_MESH_MODIFIER_PLUGIN(EuclideanClusteringMeshModifier, EuclideanClustering)
 EXPORT_SIMPLE_MESH_MODIFIER_PLUGIN(FillHoles, FillHoles)
 EXPORT_SIMPLE_MESH_MODIFIER_PLUGIN(NormalEstimationPCLMeshModifier, NormalEstimationPCL)


### PR DESCRIPTION
This PR adds a cylinder projection mesh modifier, ported from the [`noether_roscon_2024` workshop repository](https://github.com/marip8/noether_roscon_2024/tree/7212e336c7cfb8e9635665946e14861591153e21/src/solution/exercise_2b)