### PR TITLE
Normalizing computed axes in direction of travel orientation modifier

### DIFF
--- a/noether_tpp/src/tool_path_modifiers/direction_of_travel_orientation_modifier.cpp
+++ b/noether_tpp/src/tool_path_modifiers/direction_of_travel_orientation_modifier.cpp
@@ -29,13 +29,13 @@ ToolPaths DirectionOfTravelOrientationModifier::modify(ToolPaths tool_paths) con
         Eigen::Isometry3d& waypoint = segment[i];
 
         // Keep the z-axis from the original waypoint
-        const Eigen::Vector3d z_axis = waypoint.matrix().col(2).head<3>();
+        const Eigen::Vector3d z_axis = waypoint.matrix().col(2).head<3>().normalized();
 
         // Compute the new y-axis from the original z-axis and the reference direction
-        const Eigen::Vector3d y_axis = z_axis.cross(reference_x_dir);
+        const Eigen::Vector3d y_axis = z_axis.cross(reference_x_dir).normalized();
 
         // Compute the new x-axis from the new y-axis and the original z-axis
-        const Eigen::Vector3d x_axis = y_axis.cross(z_axis);
+        const Eigen::Vector3d x_axis = y_axis.cross(z_axis).normalized();
 
         // Update the waypoint orientation
         waypoint.matrix().col(0).head<3>() = x_axis;


### PR DESCRIPTION
Normalizing the computed axes in the direction of travel orientation modifier to prevent floating point rounding error from propagating through the tpp pipeline. 

A bug was discovered where the determinant of the waypoints lose precision after this modifier is added to the raster planner output. 