### PR TITLE
Fix vertex normal vector normalization

### DIFF
--- a/noether_tpp/src/mesh_modifiers/normals_from_mesh_faces_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/normals_from_mesh_faces_modifier.cpp
@@ -21,12 +21,8 @@ std::vector<pcl::PolygonMesh> NormalsFromMeshFacesMeshModifier::modify(const pcl
   // Iterate across the polygons, calculating their normals and accumulating the normals onto all adjacent vertices
   for (const auto& p : mesh.polygons)
   {
-    // Compute the normal
-    const Eigen::Vector3f normal = getFaceNormal(mesh, p);
-
-    // Add this normal to the accumulators for this face's valid vertices
-    for (const std::size_t v_idx : p.vertices)
-      normals_map.col(v_idx).head<3>() += normal;
+    // Compute the normal and add to the accumulators for this face's valid vertices
+    normals_map({ 0, 1, 2 }, p.vertices).colwise() += getFaceNormal(mesh, p);
   }
 
   // Normalize the normals


### PR DESCRIPTION
#334 introduced a bug during the normal vector normalization in which the entire column of the mapped normal cloud was used for normalization. The mapped column size is 8 (`[nx, ny, nz, 0, curvature, 0, 0, 0]`) but only the first 3 columns need to be normalized