### PR TITLE
Include header in primitive fit/projection sub-meshes

### DIFF
--- a/noether_tpp/src/mesh_modifiers/ransac_cylinder_fit_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/ransac_cylinder_fit_modifier.cpp
@@ -161,6 +161,10 @@ pcl::PolygonMesh RansacCylinderProjectionMeshModifier::createSubMesh(
   // Project the mesh
   projectInPlace(output_mesh.cloud, coefficients);
 
+  // Copy the headers from the input mesh to the output mesh
+  output_mesh.cloud.header = mesh.cloud.header;
+  output_mesh.header = mesh.header;
+
   return output_mesh;
 }
 
@@ -252,10 +256,18 @@ pcl::PolygonMesh RansacCylinderFitMeshModifier::createSubMesh(
   const Eigen::Isometry3d transform = createTransform(origin.cast<double>(), axis.cast<double>());
 
   // Create the cylinder primitive
+  pcl::PolygonMesh output_mesh;
   if (uniform_triangles_)
-    return createCylinderMeshWithUniformTriangles(radius, length, resolution_, 2.0 * M_PI, include_caps_, transform);
+    output_mesh =
+        createCylinderMeshWithUniformTriangles(radius, length, resolution_, 2.0 * M_PI, include_caps_, transform);
   else
-    return createCylinderMesh(radius, length, resolution_, 2.0 * M_PI, include_caps_, transform);
+    output_mesh = createCylinderMesh(radius, length, resolution_, 2.0 * M_PI, include_caps_, transform);
+
+  // Copy the headers from the input mesh to the output mesh
+  output_mesh.cloud.header = mesh.cloud.header;
+  output_mesh.header = mesh.header;
+
+  return output_mesh;
 }
 
 }  // namespace noether

--- a/noether_tpp/src/mesh_modifiers/ransac_plane_fit_modifier.cpp
+++ b/noether_tpp/src/mesh_modifiers/ransac_plane_fit_modifier.cpp
@@ -107,6 +107,10 @@ pcl::PolygonMesh RansacPlaneProjectionMeshModifier::createSubMesh(
     if (dot_products[i] < 0.0)
       std::reverse(output_mesh.polygons[i].vertices.begin(), output_mesh.polygons[i].vertices.end());
 
+  // Copy the headers from the input mesh to the output mesh
+  output_mesh.cloud.header = mesh.cloud.header;
+  output_mesh.header = mesh.header;
+
   return output_mesh;
 }
 


### PR DESCRIPTION
The shape primitive fit/projection mesh modifiers do not currently propagate the header information in the mesh and vertex cloud. This prevents users from using downstream mesh modifiers that require that information, such as the [ROI selection mesh modifier in Scan-N-Plan](https://github.com/ros-industrial-consortium/scan_n_plan_workshop/blob/7060e12c04c2a3571feac60e0193a7c84859ebae/snp_tpp/include/snp_tpp/roi_selection_mesh_modifier.h) which uses the frame ID to do a TF lookup. This PR updates the primitive fit/projection mesh modifiers to copy the header information from the input mesh into the generated sub-meshes