### PR TITLE
Added default no-op implementation of BaseWidget::save

### DIFF
--- a/noether_gui/include/noether_gui/widgets.h
+++ b/noether_gui/include/noether_gui/widgets.h
@@ -22,7 +22,7 @@ public:
   /**
    * @brief Saves the configuration of the widget to a YAML node
    */
-  virtual void save(YAML::Node&) const = 0;
+  virtual void save(YAML::Node&) const {};
 };
 
 }  // namespace noether


### PR DESCRIPTION
Adds a default implementation of the `BaseWidget::save` method so TPP components that can use an empty widget for their representation in the GUI can declare a widget class with `using MyTppWidget = BaseWidget;`