### PR TITLE
Add plane slicer raster planner with legacy behavior

### DIFF
--- a/noether_gui/CMakeLists.txt
+++ b/noether_gui/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
   src/widgets/tool_path_planners/raster/origin_generators/centroid_origin_generator_widget.cpp
   # Plane Slicer Tool Path Planner
   src/widgets/tool_path_planners/raster/plane_slicer_raster_planner_widget.cpp
+  src/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.cpp
   src/widgets/tool_path_planners/raster/cross_hatch_plane_slicer_raster_planner.cpp
   # Half Edge Planner
   src/widgets/tool_path_planners/edge/boundary_edge_planner_widget.cpp

--- a/noether_gui/include/noether_gui/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.h
+++ b/noether_gui/include/noether_gui/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <noether_gui/widgets/tool_path_planners/raster/raster_planner_widget.h>
+
+class QCheckBox;
+
+namespace Ui
+{
+class PlaneSlicerLegacyRasterPlanner;
+}
+
+namespace noether
+{
+/**
+ * @ingroup gui_widgets_tool_path_planners
+ */
+class PlaneSlicerLegacyRasterPlannerWidget : public RasterPlannerWidget
+{
+public:
+  PlaneSlicerLegacyRasterPlannerWidget(std::shared_ptr<const WidgetFactory> factory, QWidget* parent = nullptr);
+
+  void configure(const YAML::Node&) override;
+  void save(YAML::Node&) const override;
+
+protected:
+  Ui::PlaneSlicerLegacyRasterPlanner* ui_plane_slicer_;
+};
+
+}  // namespace noether

--- a/noether_gui/src/plugins.cpp
+++ b/noether_gui/src/plugins.cpp
@@ -12,6 +12,7 @@
 #include <noether_gui/widgets/tool_path_planners/raster/origin_generators/centroid_origin_generator_widget.h>
 // Tool path planners
 #include <noether_gui/widgets/tool_path_planners/raster/raster_planner_widget.h>
+#include <noether_gui/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.h>
 #include <noether_gui/widgets/tool_path_planners/raster/cross_hatch_plane_slicer_raster_planner_widget.h>
 // Tool Path Modifiers
 #include <noether_gui/widgets/tool_path_modifiers/circular_lead_in_modifier_widget.h>
@@ -98,6 +99,35 @@ struct Plugin_CrossHatchPlaneSlicerRasterPlannerWidget : WidgetPlugin
   }
 };
 EXPORT_TOOL_PATH_PLANNER_WIDGET_PLUGIN(noether::Plugin_CrossHatchPlaneSlicerRasterPlannerWidget, CrossHatchPlaneSlicer)
+
+// For a complex plugin that cannot be configured through YAML serialization alone, implement a custom plugin class.
+struct Plugin_PlaneSlicerLegacyRasterPlannerWidget : WidgetPlugin
+{
+  BaseWidget* create(const YAML::Node& config,
+                     std::shared_ptr<const WidgetFactory> factory,
+                     QWidget* parent = nullptr) const override final
+  {
+    auto widget = new PlaneSlicerLegacyRasterPlannerWidget(factory, parent);
+
+    // Attempt to configure the widget
+    if (!config.IsNull())
+    {
+      try
+      {
+        widget->configure(config);
+      }
+      catch (const std::exception&)
+      {
+        // Delete the widget to prevent it from showing up in the GUI outside of the appropriate layout
+        widget->deleteLater();
+        throw;
+      }
+    }
+
+    return widget;
+  }
+};
+EXPORT_TOOL_PATH_PLANNER_WIDGET_PLUGIN(Plugin_PlaneSlicerLegacyRasterPlannerWidget, PlaneSlicerLegacy)
 
 // Tool Path Modifiers
 EXPORT_SIMPLE_TOOL_PATH_MODIFIER_WIDGET_PLUGIN(StandardEdgePathsOrganizationModifierWidget,

--- a/noether_gui/src/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.cpp
+++ b/noether_gui/src/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.cpp
@@ -1,0 +1,50 @@
+#include <noether_gui/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.h>
+#include "ui_plane_slicer_legacy_raster_planner_widget.h"
+
+#include <noether_tpp/serialization.h>
+#include <QGroupBox>
+
+static const std::string POINT_SPACING_KEY = "point_spacing";
+static const std::string MIN_HOLE_SIZE_KEY = "min_hole_size";
+static const std::string MIN_SEGMENT_SIZE_KEY = "min_segment_size";
+static const std::string BIDIRECTIONAL_KEY = "bidirectional";
+
+namespace noether
+{
+PlaneSlicerLegacyRasterPlannerWidget::PlaneSlicerLegacyRasterPlannerWidget(std::shared_ptr<const WidgetFactory> factory,
+                                                                           QWidget* parent)
+  : RasterPlannerWidget(factory, parent), ui_plane_slicer_(new Ui::PlaneSlicerLegacyRasterPlanner())
+{
+  auto widget = new QGroupBox(this);
+  ui_plane_slicer_->setupUi(widget);
+  layout()->addWidget(widget);
+}
+
+void PlaneSlicerLegacyRasterPlannerWidget::configure(const YAML::Node& config)
+{
+  RasterPlannerWidget::configure(config);
+  ui_plane_slicer_->double_spin_box_point_spacing->setValue(YAML::getMember<double>(config, POINT_SPACING_KEY));
+  ui_plane_slicer_->double_spin_box_minimum_hole_size->setValue(YAML::getMember<double>(config, MIN_HOLE_SIZE_KEY));
+  ui_plane_slicer_->double_spin_box_min_segment_size->setValue(YAML::getMember<double>(config, MIN_SEGMENT_SIZE_KEY));
+
+  // Optionally get bidirectional parameter to maintain backwards compatibility
+  try
+  {
+    ui_plane_slicer_->check_box_bidirectional->setChecked(YAML::getMember<bool>(config, BIDIRECTIONAL_KEY));
+  }
+  catch (const std::exception& ex)
+  {
+  }
+}
+
+void PlaneSlicerLegacyRasterPlannerWidget::save(YAML::Node& config) const
+{
+  config["name"] = "PlaneSlicerLegacy";
+  RasterPlannerWidget::save(config);
+  config[POINT_SPACING_KEY] = ui_plane_slicer_->double_spin_box_point_spacing->value();
+  config[MIN_HOLE_SIZE_KEY] = ui_plane_slicer_->double_spin_box_minimum_hole_size->value();
+  config[MIN_SEGMENT_SIZE_KEY] = ui_plane_slicer_->double_spin_box_min_segment_size->value();
+  config[BIDIRECTIONAL_KEY] = ui_plane_slicer_->check_box_bidirectional->isChecked();
+}
+
+}  // namespace noether

--- a/noether_gui/src/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.ui
+++ b/noether_gui/src/widgets/tool_path_planners/raster/plane_slicer_legacy_raster_planner_widget.ui
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PlaneSlicerLegacyRasterPlanner</class>
+ <widget class="QWidget" name="PlaneSlicerLegacyRasterPlanner">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>282</width>
+    <height>135</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_point_spacing">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Distance between tool path waypoints on a raster line&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Point Spacing</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="noether::DistanceDoubleSpinBox" name="double_spin_box_point_spacing">
+     <property name="decimals">
+      <number>3</number>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.025000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_min_hole_size">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The size of the smallest hole that the tool path planner should not jump over&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Minimum Hole Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="noether::DistanceDoubleSpinBox" name="double_spin_box_minimum_hole_size">
+     <property name="decimals">
+      <number>3</number>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_min_segment_size">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tool path segments shorter than this length will not be included&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Min Segment Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="noether::DistanceDoubleSpinBox" name="double_spin_box_min_segment_size">
+     <property name="decimals">
+      <number>3</number>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Generate rasters in the direction of the cut plane normal and its negation&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Bidirectional</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="check_box_bidirectional">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>noether::DistanceDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header location="global">noether_gui/widgets/distance_double_spin_box.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>double_spin_box_point_spacing</tabstop>
+  <tabstop>double_spin_box_minimum_hole_size</tabstop>
+  <tabstop>double_spin_box_min_segment_size</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/noether_tpp/CMakeLists.txt
+++ b/noether_tpp/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(
   src/tool_path_planners/raster/direction_generators/principal_axis_direction_generator.cpp
   src/tool_path_planners/raster/direction_generators/pca_rotated_direction_generator.cpp
   src/tool_path_planners/raster/plane_slicer_raster_planner.cpp
+  src/tool_path_planners/raster/plane_slicer_legacy_raster_planner.cpp
 )
 
 if(${CMAKE_VERSION} VERSION_GREATER 3.15)

--- a/noether_tpp/include/noether_tpp/tool_path_planners/raster/plane_slicer_legacy_raster_planner.h
+++ b/noether_tpp/include/noether_tpp/tool_path_planners/raster/plane_slicer_legacy_raster_planner.h
@@ -1,0 +1,56 @@
+/**
+ * @file plane_slicer_legacy_raster_planner.h
+ * @copyright Copyright (c) 2021, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <noether_tpp/tool_path_planners/raster/plane_slicer_raster_planner.h>
+
+namespace noether
+{
+/**
+ * @ingroup raster_planners
+ * @details Implementation of the legacy PlaneSlicerRasterPlanner, which includes control over point spacing, minimum
+ * segment size, and minimum hole size.
+ */
+class PlaneSlicerLegacyRasterPlanner : public PlaneSlicerRasterPlanner
+{
+public:
+  /**
+   * @brief Constructor
+   * @param dir_gen Direction generator
+   * @param origin_gen Origin generator
+   * @param point_spacing Distance between waypoints on the same raster line (m)
+   * @param min_segment_size Minimum length of valid segment (m)
+   * @param min_hole_size Minimum size of hole in a mesh for which the planner should split a raster line that
+   * crosses over the hole into multiple segments
+   */
+  PlaneSlicerLegacyRasterPlanner(DirectionGenerator::ConstPtr dir_gen,
+                                 OriginGenerator::ConstPtr origin_gen,
+                                 const double point_spacing,
+                                 const double min_segment_size,
+                                 const double min_hole_size);
+
+protected:
+  ToolPaths planImpl(const pcl::PolygonMesh& mesh) const;
+
+  double point_spacing_;
+  double min_segment_size_;
+  double min_hole_size_;
+};
+
+}  // namespace noether

--- a/noether_tpp/src/tool_path_planners/raster/plane_slicer_legacy_raster_planner.cpp
+++ b/noether_tpp/src/tool_path_planners/raster/plane_slicer_legacy_raster_planner.cpp
@@ -1,0 +1,35 @@
+#include <noether_tpp/tool_path_planners/raster/plane_slicer_legacy_raster_planner.h>
+#include <noether_tpp/tool_path_modifiers/compound_modifier.h>
+#include <noether_tpp/tool_path_modifiers/join_close_segments_modifier.h>
+#include <noether_tpp/tool_path_modifiers/minimum_segment_length_modifier.h>
+#include <noether_tpp/tool_path_modifiers/uniform_spacing_modifier.h>
+#include <noether_tpp/utils.h>
+
+namespace noether
+{
+PlaneSlicerLegacyRasterPlanner::PlaneSlicerLegacyRasterPlanner(DirectionGenerator::ConstPtr dir_gen,
+                                                               OriginGenerator::ConstPtr origin_gen,
+                                                               const double point_spacing,
+                                                               const double min_segment_size,
+                                                               const double min_hole_size)
+  : PlaneSlicerRasterPlanner(std::move(dir_gen), std::move(origin_gen))
+  , point_spacing_(point_spacing)
+  , min_segment_size_(min_segment_size)
+  , min_hole_size_(min_hole_size)
+{
+}
+
+ToolPaths PlaneSlicerLegacyRasterPlanner::planImpl(const pcl::PolygonMesh& mesh) const
+{
+  // Create a compound tool path modifier for 1) joining segments closer than the minimum hole size, 2) pruning segments
+  // less than the minimum required length, and 3) uniformly linearly sampling waypoints on the tool path
+  std::vector<ToolPathModifier::ConstPtr> mods(3);
+  mods[0] = std::make_unique<JoinCloseSegmentsToolPathModifier>(min_hole_size_);
+  mods[1] = std::make_unique<const MinimumSegmentLengthToolPathModifier>(min_segment_size_);
+  mods[2] = std::make_unique<const UniformSpacingModifier>(point_spacing_, 1l, true);
+  CompoundModifier mod(std::move(mods));
+
+  return mod.modify(PlaneSlicerRasterPlanner::planImpl(mesh));
+}
+
+}  // namespace noether


### PR DESCRIPTION
PR #350 revised the plane slicer raster planner to remove control over the minimum hole size, minimum segment length and point spacing in favor of performing these tasks with tool path modifiers (which all now exist). For convenience, this PR adds a new plane slicer raster planner (called `PlaneSlicerLegacy`) that has the same functionality as the plane slice planner before the changes introduced in #350. The new tool path modifiers are embedded directly in the planner to provide control over the min hole size, min segment length, and point spacing.